### PR TITLE
feat: #84/Atom Component - Modal

### DIFF
--- a/src/components/atoms/Modal/Modal.tsx
+++ b/src/components/atoms/Modal/Modal.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Colors, Shadow } from '@/styles';
+import { useClickAway } from '@/hooks';
+import { IconButton, Portal } from '@/components';
+
+export interface ModalProps extends React.ComponentProps<'div'> {
+  visible?: boolean;
+  onClose?: () => void;
+}
+
+const Modal = ({
+  children,
+  visible,
+  onClose,
+  ...props
+}: ModalProps): JSX.Element => {
+  const ref = useClickAway(() => {
+    onClose && onClose();
+  });
+
+  const handleClickCloseButton = () => {
+    onClose && onClose();
+  };
+
+  return (
+    <Portal>
+      <BackgroundDim visible={visible ? visible : false}>
+        <ModalContainer ref={ref} {...props}>
+          <CloseButton onClick={handleClickCloseButton} />
+          {children}
+        </ModalContainer>
+      </BackgroundDim>
+    </Portal>
+  );
+};
+
+const BackgroundDim = styled.div<
+  React.ComponentProps<'div'> & { visible: boolean }
+>`
+  display: ${({ visible }) => (visible ? 'block' : 'none')};
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+`;
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 600px;
+  min-width: 280px;
+  min-height: 100px;
+  padding: 8px;
+  border-radius: 16px;
+  background-color: ${Colors.backgroundModal};
+  box-shadow: ${Shadow.modal};
+  box-sizing: border-box;
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+  padding: 0.5rem 0.5rem 0 0;
+`;
+
+const CloseButton = styled(IconButton.Close)`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+`;
+
+export default Modal;

--- a/src/components/atoms/Modal/Modal.tsx
+++ b/src/components/atoms/Modal/Modal.tsx
@@ -63,12 +63,6 @@ const ModalContainer = styled.div`
   box-sizing: border-box;
 `;
 
-const Header = styled.div`
-  display: flex;
-  flex-direction: row-reverse;
-  padding: 0.5rem 0.5rem 0 0;
-`;
-
 const CloseButton = styled(IconButton.Close)`
   position: absolute;
   top: 1rem;

--- a/src/components/atoms/Modal/index.ts
+++ b/src/components/atoms/Modal/index.ts
@@ -1,0 +1,2 @@
+export { default as Modal } from './Modal';
+export type { ModalProps } from './Modal';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,8 @@ export { Spinner } from './atoms/Spinner';
 export type { SpinnerProps } from './atoms/Spinner';
 export { Portal } from './atoms/Portal';
 export type { PortalProps } from './atoms/Portal';
+export { Modal } from './atoms/Modal';
+export type { ModalProps } from './atoms/Modal';
 
 export { EditBox } from './molecules/ToolBox';
 export type { EditBoxProps } from './molecules/ToolBox/EditBox';

--- a/src/stories/components/atoms/Modal.stories.tsx
+++ b/src/stories/components/atoms/Modal.stories.tsx
@@ -1,0 +1,29 @@
+import { Modal, ModalProps } from '@/components';
+import styled from '@emotion/styled';
+import { useState } from 'react';
+
+export default {
+  title: 'Components/Atoms/Modal',
+  component: Modal,
+};
+
+const StyledModal = styled(Modal)`
+  width: 500px;
+  height: 300px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Default = ({ ...args }: ModalProps): JSX.Element => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div>
+      <button onClick={() => setVisible(true)}>Show Modal</button>
+      <StyledModal visible={visible} onClose={() => setVisible(false)}>
+        Hi!
+      </StyledModal>
+    </div>
+  );
+};


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

Modal 컴포넌트 구현

- closed #84 

## 🧑‍💻 PR 세부 내용

 #### Modal
- `visible: boolean` : 모달 보여지는 여부
- `onClose: () => void` : 종료로직

```js
<Modal visible={visible} onClose={() => setVisible(false)}>
  Hi!
<Modal>
```

##### 사용예시 (스토리북 참고)

```js
const StyledModal = styled(Modal)`
  width: 500px;
  height: 300px;
  display: flex;
  justify-content: center;
  align-items: center;
`;

export const Default = ({ ...args }: ModalProps): JSX.Element => {
  const [visible, setVisible] = useState(false);

  return (
    <div>
      <button onClick={() => setVisible(true)}>Show Modal</button>
      <StyledModal visible={visible} onClose={() => setVisible(false)}>
        Hi!
      </StyledModal>
    </div>
  );
};
```


## 📸 스크린샷

https://user-images.githubusercontent.com/41064875/145235778-799f5b46-8e7d-44f5-b7f8-c34e8dbc9399.mov



