### PR TITLE
refactor: #93/RoutineCategorySelector 로직 리팩토링 진행

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -38,7 +38,7 @@ export { RoutineInfo } from './molecules/RoutineInfo';
 export type { RoutineInfoProps } from './molecules/RoutineInfo';
 
 export { RoutineCategorySelector } from './molecules/RoutineCategorySelector';
-export type { RoutineCategoryItemProps } from './molecules/RoutineCategorySelector';
+export type { RoutineCategorySelectorProps } from './molecules/RoutineCategorySelector';
 export { RoutineAddButton } from './organisms/RoutineAddButton';
 export type { RoutineAddButtonProps } from './organisms/RoutineAddButton';
 export { Routine } from './molecules/Routine';

--- a/src/components/molecules/RoutineCategorySelector/RoutineCategoryItem.tsx
+++ b/src/components/molecules/RoutineCategorySelector/RoutineCategoryItem.tsx
@@ -2,28 +2,40 @@ import styled from '@emotion/styled';
 import { Colors, FontWeight, FontSize, Media } from '@/styles';
 import React from 'react';
 
-export interface RoutineCategoryItemProps extends React.ComponentProps<'div'> {
-  title?: string;
-  index?: string;
-  active?: boolean;
-  onClick?: () => void;
+export interface RoutineCategoryItemProps
+  extends React.ComponentProps<'input'> {
+  category: string;
 }
 
 const RoutineCategoryItem = ({
-  title,
-  index,
-  active,
-  onClick,
+  category,
   ...props
 }: RoutineCategoryItemProps): JSX.Element => {
   return (
-    <StyledCategoryItem active={active} onClick={onClick} {...props}>
-      {title}
-    </StyledCategoryItem>
+    <>
+      <StyledInput
+        type="radio"
+        id={category}
+        name="Category"
+        value={category}
+        {...props}
+      />
+      <label htmlFor={category}>
+        <StyledCategoryItem>{category}</StyledCategoryItem>
+      </label>
+    </>
   );
 };
 
-const StyledCategoryItem = styled.div<RoutineCategoryItemProps>`
+const StyledInput = styled.input`
+  display: none;
+  :checked + label > div {
+    background-color: ${Colors.point};
+    color: ${Colors.textQuaternary};
+  }
+`;
+
+const StyledCategoryItem = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -32,11 +44,9 @@ const StyledCategoryItem = styled.div<RoutineCategoryItemProps>`
   border: 1px solid ${Colors.pointLight};
   cursor: pointer;
   text-align: center;
+  color: ${Colors.textSecondary};
+  background-color: ${Colors.backgroundButton};
   font-weight: ${FontWeight.medium};
-  ${({ active }) => `background-color: ${
-    active ? Colors.point : Colors.backgroundButton
-  };
-  color: ${active ? Colors.textQuaternary : Colors.textSecondary};`}
   @media ${Media.sm} {
     min-width: 64px;
     min-height: 32px;

--- a/src/components/molecules/RoutineCategorySelector/RoutineCategorySelector.tsx
+++ b/src/components/molecules/RoutineCategorySelector/RoutineCategorySelector.tsx
@@ -1,64 +1,58 @@
+import { RoutineCategoryItemProps } from '@/components';
+import { Media } from '@/styles';
 import styled from '@emotion/styled';
-import React, {
-  useState,
-  useMemo,
-  Children,
-  ReactElement,
-  cloneElement,
-} from 'react';
-import RoutineCategoryItem, {
-  RoutineCategoryItemProps,
-} from './RoutineCategoryItem';
+import { ChangeEvent } from 'react';
+import RoutineCategoryItem from './RoutineCategoryItem';
+
+export interface RoutineCategorySelectorProps extends RoutineCategoryItemProps {
+  categories: string[];
+}
 
 const RoutineCategorySelector = ({
-  children,
-  active,
+  category,
+  categories,
+  onChange,
   ...props
-}: RoutineCategoryItemProps): JSX.Element => {
-  const [activeTab, setActiveTab] = useState<string>(() => {
-    if (active) {
-      return active;
-    } else {
-      const initialIndex = Children.toArray(children)[0] as ReactElement;
-      return initialIndex.props.index;
-    }
-  });
-  const items = useMemo(() => {
-    return Children.map(children, (child) => {
-      const item = child as ReactElement;
-      return cloneElement(item, {
-        ...item.props,
-        active: item.props.index === activeTab,
-        onClick: () => {
-          setActiveTab(item.props.index);
-        },
-      });
-    });
-  }, [children, activeTab]);
-  const activeItem = useMemo(
-    () => items?.find((element) => activeTab === element.props.index),
-    [activeTab, items],
-  );
+}: RoutineCategorySelectorProps): JSX.Element => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange && onChange(e);
+  };
+
   return (
-    <>
-      <RoutineCategoryContainer {...props}>{items}</RoutineCategoryContainer>
-      <div>{activeItem?.props.children}</div>
-    </>
+    <RoutineCategoryContainer>
+      {categories &&
+        categories.map((category) => (
+          <RoutineCategoryItem
+            category={category}
+            onChange={handleChange}
+            key={category}
+            {...props}
+          />
+        ))}
+    </RoutineCategoryContainer>
   );
 };
 
-RoutineCategorySelector.Item = RoutineCategoryItem;
+const defaultProps = {
+  categories: ['전체', '운동', '건강', '개발', '기타'],
+  category: '전체',
+};
+
+RoutineCategorySelector.defaultProps = defaultProps;
 
 const RoutineCategoryContainer = styled.div`
   width: 100%;
   height: 40px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   white-space: nowrap;
   overflow-x: scroll;
-  div:not(:last-of-type) {
+  label:not(:last-of-type) {
     margin-right: 16px;
+    @media ${Media.sm} {
+      margin-right: 8px;
+    }
   }
   -ms-overflow-style: none;
   &::-webkit-scrollbar {

--- a/src/components/molecules/RoutineCategorySelector/RoutineCategorySelector.tsx
+++ b/src/components/molecules/RoutineCategorySelector/RoutineCategorySelector.tsx
@@ -1,8 +1,9 @@
-import { RoutineCategoryItemProps } from '@/components';
 import { Media } from '@/styles';
 import styled from '@emotion/styled';
 import { ChangeEvent } from 'react';
-import RoutineCategoryItem from './RoutineCategoryItem';
+import RoutineCategoryItem, {
+  RoutineCategoryItemProps,
+} from './RoutineCategoryItem';
 
 export interface RoutineCategorySelectorProps extends RoutineCategoryItemProps {
   categories: string[];

--- a/src/components/molecules/RoutineCategorySelector/index.ts
+++ b/src/components/molecules/RoutineCategorySelector/index.ts
@@ -1,2 +1,2 @@
 export { default as RoutineCategorySelector } from './RoutineCategorySelector';
-export type { RoutineCategoryItemProps } from './RoutineCategoryItem';
+export type { RoutineCategorySelectorProps } from './RoutineCategorySelector';

--- a/src/stories/components/molecules/RoutineCategorySelector.stories.tsx
+++ b/src/stories/components/molecules/RoutineCategorySelector.stories.tsx
@@ -1,23 +1,16 @@
-import {
-  RoutineCategorySelector,
-  RoutineCategoryItemProps,
-} from '@/components';
+import { RoutineCategorySelector } from '@/components';
+import { RoutineCategorySelectorProps } from '@/components/molecules/RoutineCategorySelector/RoutineCategorySelector';
 
 export default {
   title: 'Components/Molecules/RoutineCategorySelector',
   component: RoutineCategorySelector,
+  argTypes: {
+    onChange: { actions: 'onChange' },
+  },
 };
 
-export const Default = ({ ...args }: RoutineCategoryItemProps): JSX.Element => {
-  const categoryList = ['전체', '건강', '운동', '개발'];
-  return (
-    <RoutineCategorySelector {...args}>
-      {categoryList &&
-        categoryList.map((item, i) => (
-          <RoutineCategorySelector.Item key={i} title={item} index={String(i)}>
-            <h1>{item}</h1>
-          </RoutineCategorySelector.Item>
-        ))}
-    </RoutineCategorySelector>
-  );
+export const Default = ({
+  ...args
+}: RoutineCategorySelectorProps): JSX.Element => {
+  return <RoutineCategorySelector {...args} />;
 };

--- a/src/stories/components/molecules/RoutineCategorySelector.stories.tsx
+++ b/src/stories/components/molecules/RoutineCategorySelector.stories.tsx
@@ -1,5 +1,7 @@
-import { RoutineCategorySelector } from '@/components';
-import { RoutineCategorySelectorProps } from '@/components/molecules/RoutineCategorySelector/RoutineCategorySelector';
+import {
+  RoutineCategorySelector,
+  RoutineCategorySelectorProps,
+} from '@/components';
 
 export default {
   title: 'Components/Molecules/RoutineCategorySelector',


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

RoutineCategorySelector 로직 리팩토링

## 🧑‍💻 PR 세부 내용

- input radio로 리팩토링 진행했습니다
- 스타일에는 flex-start와 margin 반응형을 추가했습니다 
- categories와 category에 defaultProps을 걸어놨습니다
``` 
const defaultProps = {
  categories: ['전체', '운동', '건강', '개발', '기타'],
  category: '전체',
 };
```
- closed #93
## 📸 스크린샷

https://user-images.githubusercontent.com/77623643/145367154-ecec5f71-1b03-4ac3-902c-00f12226d69b.mov



