### PR TITLE
feat: #108/Organism Component - DurationTimePicker

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -52,8 +52,9 @@ export type { RoutineAddButtonProps } from './organisms/RoutineAddButton';
 export { EmojiPicker } from './organisms/EmojiPicker';
 export type { EmojiPickerProps } from './organisms/EmojiPicker';
 export { StartTimePicker } from './organisms/StartTimePicker';
+export { DurationTimePicker } from './organisms/DurationTimePicker';
 
-//! Organism Component
+//! Template Component
 export { Container } from './templates/Container';
 export type { ContainerProps } from './templates/Container';
 export { Header } from './templates/Header';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -53,6 +53,7 @@ export { EmojiPicker } from './organisms/EmojiPicker';
 export type { EmojiPickerProps } from './organisms/EmojiPicker';
 export { StartTimePicker } from './organisms/StartTimePicker';
 export { DurationTimePicker } from './organisms/DurationTimePicker';
+export type { DurationTimePickerProps } from './organisms/DurationTimePicker';
 
 //! Template Component
 export { Container } from './templates/Container';

--- a/src/components/organisms/DurationTimePicker/DurationTimePicker.tsx
+++ b/src/components/organisms/DurationTimePicker/DurationTimePicker.tsx
@@ -30,7 +30,6 @@ const DurationTimePicker = ({
           views={['hours', 'minutes', 'seconds']}
           inputFormat="HH시간 mm분 ss초"
           mask="__:__:__"
-          label="지속 시간"
           value={time}
           onChange={handleChange}
           shouldDisableTime={(timeValue, clockType) => {

--- a/src/components/organisms/DurationTimePicker/DurationTimePicker.tsx
+++ b/src/components/organisms/DurationTimePicker/DurationTimePicker.tsx
@@ -29,7 +29,7 @@ const DurationTimePicker = ({
           openTo="hours"
           views={['hours', 'minutes', 'seconds']}
           inputFormat="HH시간 mm분 ss초"
-          mask="__:__:__"
+          disableMaskedInput={true}
           value={time}
           onChange={handleChange}
           shouldDisableTime={(timeValue, clockType) => {

--- a/src/components/organisms/DurationTimePicker/DurationTimePicker.tsx
+++ b/src/components/organisms/DurationTimePicker/DurationTimePicker.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import AdapterDateFns from '@mui/lab/AdapterMoment';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import { TimePicker } from '@mui/lab';
+import { InputProps } from '@/components';
+import { TextField } from '@mui/material';
+
+const DurationTimePicker = ({ onChange }: InputProps): JSX.Element => {
+  const [time, setTime] = React.useState(new Date(0, 0, 0, 1));
+  const handleChange = (value: any) => {
+    setTime(value);
+    onChange && onChange(value);
+  };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <TimePicker
+        ampm={false}
+        ampmInClock={false}
+        views={['hours', 'minutes', 'seconds']}
+        inputFormat="hh시간 mm분 ss초"
+        mask="__:__"
+        label="지속 시간"
+        value={time}
+        shouldDisableTime={(timeValue, clockType) => {
+          if (clockType === 'hours' && timeValue > 1) {
+            return true;
+          }
+          return false;
+        }}
+        onChange={handleChange}
+        renderInput={(params) => <TextField {...params} />}
+      />
+    </LocalizationProvider>
+  );
+};
+
+export default DurationTimePicker;

--- a/src/components/organisms/DurationTimePicker/DurationTimePicker.tsx
+++ b/src/components/organisms/DurationTimePicker/DurationTimePicker.tsx
@@ -2,36 +2,47 @@ import React from 'react';
 import AdapterDateFns from '@mui/lab/AdapterMoment';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
 import { TimePicker } from '@mui/lab';
-import { InputProps } from '@/components';
 import { TextField } from '@mui/material';
+import moment from 'moment';
 
-const DurationTimePicker = ({ onChange }: InputProps): JSX.Element => {
+export interface DurationTimePickerProps {
+  onChange: (time: number) => void;
+}
+const DurationTimePicker = ({
+  onChange,
+}: DurationTimePickerProps): JSX.Element => {
   const [time, setTime] = React.useState(new Date(0, 0, 0, 1));
   const handleChange = (value: any) => {
     setTime(value);
-    onChange && onChange(value);
+    const calculateDurationTime =
+      moment(value).hours() * 3600 +
+      moment(value).minutes() * 60 +
+      moment(value).seconds();
+    onChange && onChange(calculateDurationTime);
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <TimePicker
-        ampm={false}
-        ampmInClock={false}
-        views={['hours', 'minutes', 'seconds']}
-        inputFormat="hh시간 mm분 ss초"
-        mask="__:__"
-        label="지속 시간"
-        value={time}
-        shouldDisableTime={(timeValue, clockType) => {
-          if (clockType === 'hours' && timeValue > 1) {
-            return true;
-          }
-          return false;
-        }}
-        onChange={handleChange}
-        renderInput={(params) => <TextField {...params} />}
-      />
-    </LocalizationProvider>
+    <>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <TimePicker
+          ampm={false}
+          openTo="hours"
+          views={['hours', 'minutes', 'seconds']}
+          inputFormat="HH시간 mm분 ss초"
+          mask="__:__:__"
+          label="지속 시간"
+          value={time}
+          onChange={handleChange}
+          shouldDisableTime={(timeValue, clockType) => {
+            if (clockType === 'hours' && timeValue > 1) {
+              return true;
+            }
+            return false;
+          }}
+          renderInput={(params) => <TextField {...params} />}
+        />
+      </LocalizationProvider>
+    </>
   );
 };
 

--- a/src/components/organisms/DurationTimePicker/index.ts
+++ b/src/components/organisms/DurationTimePicker/index.ts
@@ -1,1 +1,2 @@
 export { default as DurationTimePicker } from './DurationTimePicker';
+export type { DurationTimePickerProps } from './DurationTimePicker';

--- a/src/components/organisms/DurationTimePicker/index.ts
+++ b/src/components/organisms/DurationTimePicker/index.ts
@@ -1,0 +1,1 @@
+export { default as DurationTimePicker } from './DurationTimePicker';

--- a/src/stories/components/organisms/DuratrionTimePicker.stories.tsx
+++ b/src/stories/components/organisms/DuratrionTimePicker.stories.tsx
@@ -1,0 +1,30 @@
+import { DurationTimePicker } from '@/components';
+import styled from '@emotion/styled';
+import moment from 'moment';
+
+export default {
+  title: 'Components/Organisms/DurationTimePicker',
+  component: DurationTimePicker,
+};
+
+export const Default = (): JSX.Element => {
+  const handleChange = (value: any) => {
+    const calculateDurationTime =
+      moment(value).hours() * 3600 +
+      moment(value).minutes() * 60 +
+      moment(value).seconds();
+    console.log(calculateDurationTime);
+  };
+  return (
+    <StyledDurationTimePicker>
+      <DurationTimePicker onChange={handleChange} />
+    </StyledDurationTimePicker>
+  );
+};
+
+const StyledDurationTimePicker = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/stories/components/organisms/DuratrionTimePicker.stories.tsx
+++ b/src/stories/components/organisms/DuratrionTimePicker.stories.tsx
@@ -1,6 +1,5 @@
 import { DurationTimePicker } from '@/components';
 import styled from '@emotion/styled';
-import moment from 'moment';
 
 export default {
   title: 'Components/Organisms/DurationTimePicker',
@@ -9,11 +8,7 @@ export default {
 
 export const Default = (): JSX.Element => {
   const handleChange = (value: any) => {
-    const calculateDurationTime =
-      moment(value).hours() * 3600 +
-      moment(value).minutes() * 60 +
-      moment(value).seconds();
-    console.log(calculateDurationTime);
+    console.log(value);
   };
   return (
     <StyledDurationTimePicker>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

미션 생성 페이지에 사용될 DurationTimePicker 컴포넌트 구현
- closed #108 

## 🧑‍💻 PR 세부 내용

- 기본 값은 1시간으로 설정된 상태입니다
- 미션 최대 지속 시간이 2시간이므로 시계에서 0시간과 1시간만 선택이 가능하도록 구현했습니다
- 시간 선택 완료 후 시간을 초로 변경한 duration time을 전달해줍니다 

## 📸 스크린샷

https://user-images.githubusercontent.com/77623643/145710213-2d63ffed-a09b-4788-84cd-6a8b7da4d88d.mov



