### PR TITLE
feat: #105/Page Component - RoutinePostDetailPage

### DIFF
--- a/src/Models/dummy.ts
+++ b/src/Models/dummy.ts
@@ -1,4 +1,4 @@
-import { UserType } from '@/Models';
+import { UserType, RoutineType } from '@/Models';
 
 export const userDummy: UserType = {
   userId: 123,
@@ -6,4 +6,16 @@ export const userDummy: UserType = {
   nickName: '아이엠보이',
   profileImageUrl: 'https://picsum.photos/200',
   email: 'yas@yas.com',
+};
+
+export const routineDummy: RoutineType = {
+  routineId: 123,
+  title: '집 앞 공원 산책하기',
+  emoji: '🌳',
+  color: '#66CE92',
+  startGoalTime: `${new Date(2021, 12, 24, 12, 0).toISOString()}`,
+  durationGoalTime: 1000,
+  weeks: ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
+  routineCategories: ['HEALTH', 'EXERCISE'],
+  missions: [],
 };

--- a/src/Models/dummy.ts
+++ b/src/Models/dummy.ts
@@ -1,4 +1,10 @@
-import { UserType, RoutineType, RoutinePostType } from '@/Models';
+import {
+  UserType,
+  RoutineType,
+  RoutinePostType,
+  MissionType,
+  CommentType,
+} from '@/Models';
 
 export const userDummy: UserType = {
   userId: 123,
@@ -20,6 +26,14 @@ export const routineDummy: RoutineType = {
   missions: [],
 };
 
+export const missionDummy: MissionType = {
+  missionId: 333,
+  emoji: '🚿',
+  title: '샤워하기',
+  color: '#89C0F9',
+  durationGoalTime: 3600,
+};
+
 export const routinePostDummy: RoutinePostType = {
   routinePostId: 333,
   title: '집 앞 공원 산책하기',
@@ -28,5 +42,14 @@ export const routinePostDummy: RoutinePostType = {
   createdAt: '2022-12-24T03:00:00.000Z',
   updatedAt: '2022-12-24T03:00:00.000Z',
   comments: [],
+  likes: [],
+};
+
+export const commentDummy: CommentType = {
+  commentId: 777,
+  text: '댓글입니다.',
+  userId: 123,
+  createdAt: '2022-12-24T03:00:00.000Z',
+  updatedAt: '2022-12-24T03:00:00.000Z',
   likes: [],
 };

--- a/src/Models/dummy.ts
+++ b/src/Models/dummy.ts
@@ -1,4 +1,4 @@
-import { UserType, RoutineType } from '@/Models';
+import { UserType, RoutineType, RoutinePostType } from '@/Models';
 
 export const userDummy: UserType = {
   userId: 123,
@@ -9,13 +9,24 @@ export const userDummy: UserType = {
 };
 
 export const routineDummy: RoutineType = {
-  routineId: 123,
+  routineId: 321,
   title: '집 앞 공원 산책하기',
   emoji: '🌳',
   color: '#66CE92',
-  startGoalTime: `${new Date(2021, 12, 24, 12, 0).toISOString()}`,
+  startGoalTime: '2022-12-24T03:00:00.000Z',
   durationGoalTime: 1000,
   weeks: ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
   routineCategories: ['HEALTH', 'EXERCISE'],
   missions: [],
+};
+
+export const routinePostDummy: RoutinePostType = {
+  routinePostId: 333,
+  title: '집 앞 공원 산책하기',
+  userId: 123,
+  routineId: 321,
+  createdAt: '2022-12-24T03:00:00.000Z',
+  updatedAt: '2022-12-24T03:00:00.000Z',
+  comments: [],
+  likes: [],
 };

--- a/src/Models/index.ts
+++ b/src/Models/index.ts
@@ -11,3 +11,4 @@ export type { CommentLikeType } from './types';
 
 // !Dummy
 export { userDummy } from './dummy';
+export { routineDummy } from './dummy';

--- a/src/Models/index.ts
+++ b/src/Models/index.ts
@@ -12,3 +12,4 @@ export type { CommentLikeType } from './types';
 // !Dummy
 export { userDummy } from './dummy';
 export { routineDummy } from './dummy';
+export { routinePostDummy } from './dummy';

--- a/src/Models/index.ts
+++ b/src/Models/index.ts
@@ -13,3 +13,5 @@ export type { CommentLikeType } from './types';
 export { userDummy } from './dummy';
 export { routineDummy } from './dummy';
 export { routinePostDummy } from './dummy';
+export { missionDummy } from './dummy';
+export { commentDummy } from './dummy';

--- a/src/components/molecules/CommentCreator/CommentCreator.tsx
+++ b/src/components/molecules/CommentCreator/CommentCreator.tsx
@@ -45,7 +45,7 @@ const CommentCreator = ({
 const Form = styled.form`
   display: flex;
   width: 100%;
-  height: 120px;
+  height: 100px;
 `;
 
 const TextArea = styled.textarea`

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,10 +1,14 @@
+interface ConstantType {
+  [index: string]: string;
+}
+
 export const ROUTINE_TAB = Object.freeze({
   TOTAL: '전체 루틴',
   TODO: '해야할 루틴',
   COMPLETE: '완료한 루틴',
 });
 
-export const ROUTINE_CATEGORY = Object.freeze({
+export const ROUTINE_CATEGORY: ConstantType = Object.freeze({
   TOTAL: '전체',
   EXERCISE: '운동',
   GAME: '게임',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,7 +2,7 @@ interface ConstantType {
   [index: string]: string;
 }
 
-export const ROUTINE_TAB = Object.freeze({
+export const ROUTINE_TAB: ConstantType = Object.freeze({
   TOTAL: '전체 루틴',
   TODO: '해야할 루틴',
   COMPLETE: '완료한 루틴',
@@ -19,7 +19,7 @@ export const ROUTINE_CATEGORY: ConstantType = Object.freeze({
   STUDY: '공부',
 });
 
-export const WEEK = Object.freeze({
+export const WEEK: ConstantType = Object.freeze({
   MONDAY: '월',
   TUESDAY: '화',
   WEDNESDAY: '수',

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -48,12 +48,12 @@ const RoutinePostDetailPage = (): JSX.Element => {
         </BringRoutineButton>
       </RoutineInfoFooter>
       <MissionContainer open={missionOpened}>
-        <Mission missionObject={missionDummy} />
-        <Mission missionObject={missionDummy} />
-        <Mission missionObject={missionDummy} />
-        <Mission missionObject={missionDummy} />
-        <Mission missionObject={missionDummy} />
-        <Mission missionObject={missionDummy} />
+        <Mission type="create" missionObject={missionDummy} />
+        <Mission type="create" missionObject={missionDummy} />
+        <Mission type="create" missionObject={missionDummy} />
+        <Mission type="create" missionObject={missionDummy} />
+        <Mission type="create" missionObject={missionDummy} />
+        <Mission type="create" missionObject={missionDummy} />
         <SpreadButton>
           <KeyboardArrowDownRoundedIcon />
           펼치기

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -19,13 +19,14 @@ import { ROUTINE_CATEGORY } from '@/constants';
 import { Colors, Media, FontSize } from '@/styles';
 
 const missionsDummy = [
-  missionDummy,
-  missionDummy,
-  missionDummy,
-  missionDummy,
-  missionDummy,
-  missionDummy,
-  missionDummy,
+  { ...missionDummy, missionId: 1 },
+  { ...missionDummy, missionId: 2 },
+  { ...missionDummy, missionId: 3 },
+  { ...missionDummy, missionId: 4 },
+  { ...missionDummy, missionId: 5 },
+  { ...missionDummy, missionId: 6 },
+  { ...missionDummy, missionId: 7 },
+  { ...missionDummy, missionId: 8 },
 ];
 
 const RoutinePostDetailPage = (): JSX.Element => {

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -16,6 +16,7 @@ import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownR
 import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRounded';
 import { ROUTINE_CATEGORY } from '@/constants';
 import { Colors, Media, FontSize } from '@/styles';
+import { useHistory } from 'react-router-dom';
 
 const missionsDummy = [
   { ...missionDummy, missionId: 1 },
@@ -29,6 +30,7 @@ const missionsDummy = [
 ];
 
 const RoutinePostDetailPage = (): JSX.Element => {
+  const history = useHistory();
   const [missionOpened, setMissionOpened] = useState<boolean>(false);
 
   const handleClickMissionOpened = () => {
@@ -56,7 +58,11 @@ const RoutinePostDetailPage = (): JSX.Element => {
             </RoutineCategory>
           ))}
         </CategoryWrapper>
-        <BringRoutineButton>
+        <BringRoutineButton
+          onClick={() => {
+            history.push('/routine');
+          }}
+        >
           <GetAppRoundedIcon />
           루틴 가져오기
         </BringRoutineButton>

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -18,7 +18,23 @@ import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRound
 import { ROUTINE_CATEGORY } from '@/constants';
 import { Colors, Media, FontSize } from '@/styles';
 
+const missionsDummy = [
+  missionDummy,
+  missionDummy,
+  missionDummy,
+  missionDummy,
+  missionDummy,
+  missionDummy,
+  missionDummy,
+];
+
 const RoutinePostDetailPage = (): JSX.Element => {
+  const [missionOpened, setMissionOpened] = useState<boolean>(false);
+
+  const handleClickMissionOpened = () => {
+    setMissionOpened((missionOpened) => !missionOpened);
+  };
+
   return (
     <Container navBar>
       <RoutineInfoHeader>
@@ -46,14 +62,28 @@ const RoutinePostDetailPage = (): JSX.Element => {
         </BringRoutineButton>
       </RoutineInfoFooter>
       <MissionContainer>
-        <Mission type="create" missionObject={missionDummy} />
-        <Mission type="create" missionObject={missionDummy} />
-        <Mission type="create" missionObject={missionDummy} />
-        <Mission type="create" missionObject={missionDummy} />
-        <Mission type="create" missionObject={missionDummy} />
-        <Mission type="create" missionObject={missionDummy} />
+        {missionsDummy
+          .slice(0, missionOpened ? undefined : 4)
+          .map((mission: any) => (
+            <Mission
+              key={mission.missionId}
+              type="create"
+              missionObject={missionDummy}
+            />
+          ))}
       </MissionContainer>
-      <CommentCreator />
+      {missionOpened ? (
+        <SpreadButton onClick={handleClickMissionOpened}>
+          <KeyboardArrowUpRoundedIcon />
+          접기
+        </SpreadButton>
+      ) : (
+        <SpreadButton onClick={handleClickMissionOpened}>
+          <KeyboardArrowDownRoundedIcon />
+          펼치기
+        </SpreadButton>
+      )}
+      <StyledCommentCreator />
       <CommentContainer>
         <Comment user={userDummy} comment={commentDummy} />
         <Comment user={userDummy} comment={commentDummy} />
@@ -75,6 +105,7 @@ const RoutineInfoFooter = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
+  margin-top: 1rem;
 `;
 
 const AuthorInfoWrapper = styled.div`
@@ -154,21 +185,28 @@ const SpreadButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  /* background-color: ${Colors.point}; */
   border: none;
   border-radius: 1rem;
+  background-color: transparent;
   color: ${Colors.textPrimary};
   font-size: ${FontSize.small};
   padding: 0 0.5rem;
   height: 2rem;
+  cursor: pointer;
 
-  &:hover {
-    background-color: ${Colors.pointLight};
+  @media (hover: hover) {
+    :hover {
+      color: ${Colors.point};
+    }
   }
 
   &: active {
-    background-color: ${Colors.backgroundButton};
+    color: ${Colors.pointLight};
   }
+`;
+
+const StyledCommentCreator = styled(CommentCreator)`
+  margin: 2rem 0 1rem; 0;
 `;
 
 const CommentContainer = styled.div`

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -152,8 +152,10 @@ const BringRoutineButton = styled.button`
   font-size: ${FontSize.small};
   padding: 0 0.5rem;
 
-  &:hover {
-    background-color: ${Colors.pointLight};
+  @media (hover: hover) {
+    :hover {
+      background-color: ${Colors.pointLight};
+    }
   }
 
   &: active {

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import {
   Container,
   LikeBox,
@@ -8,8 +7,8 @@ import {
   Comment,
   CommentCreator,
 } from '@/components';
+import { useState } from 'react';
 import styled from '@emotion/styled';
-// import { css } from '@emotion/react';
 import { routineDummy, userDummy, missionDummy, commentDummy } from '@/Models';
 import { Avatar } from '@mui/material';
 import GetAppRoundedIcon from '@mui/icons-material/GetAppRounded';

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -1,12 +1,180 @@
-import React from 'react';
-import { Container } from '@/components';
+import React, { useState } from 'react';
+import {
+  Container,
+  LikeBox,
+  RoutineInfo,
+  RoutineCategory,
+  Mission,
+  Comment,
+  CommentCreator,
+} from '@/components';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import { routineDummy, userDummy, missionDummy, commentDummy } from '@/Models';
+import { Avatar } from '@mui/material';
+import GetAppRoundedIcon from '@mui/icons-material/GetAppRounded';
+import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
+import { ROUTINE_CATEGORY } from '@/constants';
+import { Colors, Media, FontSize } from '@/styles';
 
 const RoutinePostDetailPage = (): JSX.Element => {
+  const [missionOpened, setMissionOpened] = useState<boolean>(false);
+  const [commentOpened, setCommentOpened] = useState<boolean>(false);
+
   return (
-    <Container>
-      <h1>RoutinePostDetailPage</h1>
+    <Container navBar>
+      <RoutineInfoHeader>
+        <AuthorInfoWrapper>
+          <Avatar src={userDummy.profileImageUrl} />
+          <AuthorNameText>{userDummy.nickName}</AuthorNameText>
+        </AuthorInfoWrapper>
+        <LikeBox interactive />
+      </RoutineInfoHeader>
+      <RoutineInfo
+        createdAt={routineDummy.startGoalTime}
+        routineObject={routineDummy}
+      />
+      <RoutineInfoFooter>
+        <CategoryWrapper>
+          {routineDummy.routineCategories.map((category: string) => (
+            <RoutineCategory key={category}>
+              {ROUTINE_CATEGORY[category]}
+            </RoutineCategory>
+          ))}
+        </CategoryWrapper>
+        <BringRoutineButton>
+          <GetAppRoundedIcon />
+          루틴 가져오기
+        </BringRoutineButton>
+      </RoutineInfoFooter>
+      <MissionContainer open={missionOpened}>
+        <Mission missionObject={missionDummy} />
+        <Mission missionObject={missionDummy} />
+        <Mission missionObject={missionDummy} />
+        <Mission missionObject={missionDummy} />
+        <Mission missionObject={missionDummy} />
+        <Mission missionObject={missionDummy} />
+        <SpreadButton>
+          <KeyboardArrowDownRoundedIcon />
+          펼치기
+        </SpreadButton>
+      </MissionContainer>
+      <CommentContainer open={missionOpened}>
+        <SpreadButton>
+          댓글
+          <KeyboardArrowDownRoundedIcon />
+        </SpreadButton>
+        <Comment user={userDummy} comment={commentDummy} />
+        <Comment user={userDummy} comment={commentDummy} />
+        <Comment user={userDummy} comment={commentDummy} />
+      </CommentContainer>
+      <CommentCreator />
     </Container>
   );
 };
+
+const RoutineInfoHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  margin: 1rem 0;
+`;
+
+const RoutineInfoFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const AuthorInfoWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const AuthorNameText = styled.p``;
+
+const CategoryWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  /* width: 100%; */
+`;
+
+const BringRoutineButton = styled.button`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  background-color: ${Colors.point};
+  border: none;
+  border-radius: 1rem;
+  color: ${Colors.textQuaternary};
+  font-size: ${FontSize.small};
+  padding: 0 0.5rem;
+
+  &:hover {
+    background-color: ${Colors.pointLight};
+  }
+
+  &: active {
+    background-color: ${Colors.backgroundButton};
+  }
+
+  @media ${Media.sm} {
+    width: 140px;
+    height: 40px;
+  }
+  @media ${Media.md} {
+    width: 140px;
+    height: 40px;
+  }
+  @media ${Media.lg} {
+    width: 140px;
+    height: 40px;
+  }
+`;
+
+const MissionContainer = styled.div<
+  React.ComponentProps<'div'> & { open: boolean }
+>`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  width: 100%;
+`;
+
+const SpreadButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  /* background-color: ${Colors.point}; */
+  border: none;
+  border-radius: 1rem;
+  color: ${Colors.textPrimary};
+  font-size: ${FontSize.small};
+  padding: 0 0.5rem;
+  height: 2rem;
+
+  &:hover {
+    background-color: ${Colors.pointLight};
+  }
+
+  &: active {
+    background-color: ${Colors.backgroundButton};
+  }
+`;
+
+const CommentContainer = styled.div<
+  React.ComponentProps<'div'> & { open: boolean }
+>`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  width: 100%;
+  // height: ${({ open }) => (open ? null : '100px')};
+`;
 
 export default RoutinePostDetailPage;

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -9,23 +9,21 @@ import {
   CommentCreator,
 } from '@/components';
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
+// import { css } from '@emotion/react';
 import { routineDummy, userDummy, missionDummy, commentDummy } from '@/Models';
 import { Avatar } from '@mui/material';
 import GetAppRoundedIcon from '@mui/icons-material/GetAppRounded';
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
+import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRounded';
 import { ROUTINE_CATEGORY } from '@/constants';
 import { Colors, Media, FontSize } from '@/styles';
 
 const RoutinePostDetailPage = (): JSX.Element => {
-  const [missionOpened, setMissionOpened] = useState<boolean>(false);
-  const [commentOpened, setCommentOpened] = useState<boolean>(false);
-
   return (
     <Container navBar>
       <RoutineInfoHeader>
         <AuthorInfoWrapper>
-          <Avatar src={userDummy.profileImageUrl} />
+          <StyledAvatar src={userDummy.profileImageUrl} />
           <AuthorNameText>{userDummy.nickName}</AuthorNameText>
         </AuthorInfoWrapper>
         <LikeBox interactive />
@@ -47,28 +45,20 @@ const RoutinePostDetailPage = (): JSX.Element => {
           루틴 가져오기
         </BringRoutineButton>
       </RoutineInfoFooter>
-      <MissionContainer open={missionOpened}>
+      <MissionContainer>
         <Mission type="create" missionObject={missionDummy} />
         <Mission type="create" missionObject={missionDummy} />
         <Mission type="create" missionObject={missionDummy} />
         <Mission type="create" missionObject={missionDummy} />
         <Mission type="create" missionObject={missionDummy} />
         <Mission type="create" missionObject={missionDummy} />
-        <SpreadButton>
-          <KeyboardArrowDownRoundedIcon />
-          펼치기
-        </SpreadButton>
       </MissionContainer>
-      <CommentContainer open={missionOpened}>
-        <SpreadButton>
-          댓글
-          <KeyboardArrowDownRoundedIcon />
-        </SpreadButton>
+      <CommentCreator />
+      <CommentContainer>
         <Comment user={userDummy} comment={commentDummy} />
         <Comment user={userDummy} comment={commentDummy} />
         <Comment user={userDummy} comment={commentDummy} />
       </CommentContainer>
-      <CommentCreator />
     </Container>
   );
 };
@@ -93,7 +83,24 @@ const AuthorInfoWrapper = styled.div`
   align-items: center;
 `;
 
-const AuthorNameText = styled.p``;
+const StyledAvatar = styled(Avatar)`
+  margin-right: 0.5rem;
+`;
+
+const AuthorNameText = styled.p`
+  color: & {
+
+  }
+  @media ${Media.sm} {
+    font-size: ${FontSize.small};
+  }
+  @media ${Media.md} {
+    font-size: ${FontSize.base};
+  }
+  @media ${Media.lg} {
+    font-size: ${FontSize.base};
+  }
+`;
 
 const CategoryWrapper = styled.div`
   display: flex;
@@ -135,9 +142,7 @@ const BringRoutineButton = styled.button`
   }
 `;
 
-const MissionContainer = styled.div<
-  React.ComponentProps<'div'> & { open: boolean }
->`
+const MissionContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -166,15 +171,12 @@ const SpreadButton = styled.button`
   }
 `;
 
-const CommentContainer = styled.div<
-  React.ComponentProps<'div'> & { open: boolean }
->`
+const CommentContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
   margin: 1rem 0;
   width: 100%;
-  // height: ${({ open }) => (open ? null : '100px')};
 `;
 
 export default RoutinePostDetailPage;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

RoutinePostDetailPage 컴포넌트 구현

- closed #105 

## 🧑‍💻 PR 세부 내용

해당 페이지 자체의 레이아웃 구성을 잡았습니다.

머지된 이후 `Comment`, `CommentCreator` 컴포넌트 사이즈 및 레이아웃을 수정 하도록 하겠습니다!

## 📸 스크린샷

https://user-images.githubusercontent.com/41064875/145858058-4ec83616-0f82-47de-89df-fd4d49dd00f7.mov




