### PR TITLE
feat: #114/Page Component - RoutineFinishPage

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -56,6 +56,8 @@ export { DurationTimePicker } from './organisms/DurationTimePicker';
 export type { DurationTimePickerProps } from './organisms/DurationTimePicker';
 export { Comment } from './organisms/Comment';
 export type { CommentProps } from './organisms/Comment';
+export { RoutineProgressModal } from './organisms/RoutineProgressModal';
+export { RoutineProgress } from './organisms/RoutineProgressModal';
 
 //! Template Component
 export { Container } from './templates/Container';

--- a/src/components/organisms/RoutineProgressModal/RoutineProgress.tsx
+++ b/src/components/organisms/RoutineProgressModal/RoutineProgress.tsx
@@ -1,0 +1,119 @@
+import { Colors, FontSize, FontWeight, Media } from '@/styles';
+import TimeUtils from '@/utils/time';
+import styled from '@emotion/styled';
+import React, { Fragment } from 'react';
+
+export interface RoutineProgressProps extends React.ComponentProps<'div'> {
+  missionObject: {
+    id: string;
+    emoji: string;
+    color: string;
+    name: string;
+    durationTime: number;
+    userDurationTime?: number;
+  }[];
+}
+
+const RoutineProgress = ({
+  missionObject,
+  ...props
+}: RoutineProgressProps): JSX.Element => {
+  return (
+    <Fragment>
+      {missionObject?.map(
+        ({ id, emoji, name, durationTime, userDurationTime }) => (
+          <RoutineProgressContainer key={id}>
+            <Emoji>{emoji}</Emoji>
+            <MissionInfo>
+              <MissionName>{name}</MissionName>
+              <DurationTimeContainer>
+                <DurationTime>
+                  {TimeUtils.calculateTime(durationTime)}
+                </DurationTime>
+                {userDurationTime && (
+                  <UserDurationTime
+                    style={{
+                      color:
+                        durationTime < userDurationTime
+                          ? `${Colors.functionNegative}`
+                          : durationTime === userDurationTime
+                          ? `${Colors.textSecondary}`
+                          : `${Colors.functionPositive}`,
+                    }}
+                  >
+                    {durationTime < userDurationTime
+                      ? '(+'
+                      : durationTime === userDurationTime
+                      ? '('
+                      : '(-'}
+                    {TimeUtils.calculateTime(userDurationTime) + ')'}
+                  </UserDurationTime>
+                )}
+              </DurationTimeContainer>
+            </MissionInfo>
+          </RoutineProgressContainer>
+        ),
+      )}
+    </Fragment>
+  );
+};
+
+export default RoutineProgress;
+
+const RoutineProgressContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 2rem;
+`;
+
+const Emoji = styled.span`
+  font-size: 3rem;
+  margin-right: 2rem;
+
+  @media ${Media.sm} {
+    font-size: 2.5rem;
+    margin-right: 1rem;
+  }
+`;
+
+const MissionName = styled.h1`
+  font-size: ${FontSize.medium};
+  font-weight: ${FontWeight.medium};
+  color: ${Colors.textPrimary};
+
+  @media ${Media.sm} {
+    font-size: ${FontSize.small};
+  }
+`;
+
+const DurationTimeContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 160px);
+
+  @media ${Media.sm} {
+    grid-template-columns: repeat(2, 100px);
+  }
+`;
+
+const DurationTime = styled.p`
+  font-size: ${FontSize.medium};
+  color: ${Colors.textSecondary};
+
+  @media ${Media.sm} {
+    font-size: ${FontSize.small};
+  }
+`;
+
+const UserDurationTime = styled.p`
+  font-size: ${FontSize.medium};
+  @media ${Media.sm} {
+    font-size: ${FontSize.small};
+  }
+`;
+
+const MissionInfo = styled.div`
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column;
+  gap: 0.5rem;
+`;

--- a/src/components/organisms/RoutineProgressModal/index.ts
+++ b/src/components/organisms/RoutineProgressModal/index.ts
@@ -1,1 +1,2 @@
 export { default as RoutineProgressModal } from './RoutineProgressModal';
+export { default as RoutineProgress } from './RoutineProgress';

--- a/src/pages/myRoutine/RoutineFinishPage.tsx
+++ b/src/pages/myRoutine/RoutineFinishPage.tsx
@@ -1,12 +1,148 @@
 import React from 'react';
-import { Container } from '@/components';
+import { Button, Container, RoutineInfo, RoutineProgress } from '@/components';
+import { Colors, FontSize, FontWeight, Media } from '@/styles';
+import styled from '@emotion/styled';
+import { useHistory } from 'react-router-dom';
 
 const RoutineFinishPage = (): JSX.Element => {
+  const history = useHistory();
+  const routineDummy = {
+    emoji: '💪',
+    title: '한강에서 산책하기',
+    durationGoalTime: 12345,
+  };
+  const missionCompletionDummy: {
+    id: string;
+    emoji: string;
+    name: string;
+    durationTime: number;
+    color: string;
+    userDurationTime: number;
+  }[] = [
+    {
+      id: '10',
+      emoji: '🚿',
+      name: '샤워하기',
+      durationTime: 1200,
+      color: Colors.red,
+      userDurationTime: 1500,
+    },
+    {
+      id: '11',
+      emoji: '🪥',
+      name: '양치하기',
+      durationTime: 1200,
+      color: Colors.red,
+      userDurationTime: 1000,
+    },
+    {
+      id: '12',
+      emoji: '📝',
+      name: '공부하기',
+      durationTime: 1200,
+      color: Colors.red,
+      userDurationTime: 500,
+    },
+    {
+      id: '13',
+      emoji: '🥗',
+      name: '밥먹기',
+      durationTime: 1200,
+      color: Colors.red,
+      userDurationTime: 2500,
+    },
+    {
+      id: '14',
+      emoji: '📔',
+      name: '독서하기',
+      durationTime: 1200,
+      color: Colors.red,
+      userDurationTime: 1200,
+    },
+    {
+      id: '15',
+      emoji: '📚',
+      name: '공부하기',
+      durationTime: 1200,
+      color: Colors.red,
+      userDurationTime: 500,
+    },
+    {
+      id: '16',
+      emoji: '🎂',
+      name: '밥먹기',
+      durationTime: 1200,
+      color: Colors.red,
+      userDurationTime: 2500,
+    },
+    {
+      id: '17',
+      emoji: '📋',
+      name: '독서하기',
+      durationTime: 1200,
+      color: Colors.red,
+      userDurationTime: 1200,
+    },
+  ];
   return (
     <Container>
-      <h1>RoutineFinishPage</h1>
+      <Title>루틴 요약</Title>
+      <RoutineInfo routineObject={routineDummy} />
+      <RoutineProgressContainer>
+        <StyledRoutineProgress>
+          <RoutineProgress missionObject={missionCompletionDummy} />
+        </StyledRoutineProgress>
+      </RoutineProgressContainer>
+      <StyledButton onClick={() => history.push('/')}>종료하기</StyledButton>
     </Container>
   );
 };
 
 export default RoutineFinishPage;
+
+const Title = styled.h1`
+  margin: 1.5rem 0;
+  @media ${Media.sm} {
+    font-weight: ${FontWeight.medium};
+    font-size: ${FontSize.medium};
+  }
+  @media ${Media.md} {
+    font-weight: ${FontWeight.medium};
+    font-size: ${FontSize.large};
+  }
+  @media ${Media.lg} {
+    font-weight: ${FontWeight.medium};
+    font-size: ${FontSize.large};
+  }
+`;
+
+const RoutineProgressContainer = styled.div`
+  width: 85%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: ${Colors.backgroundModal};
+  border-radius: 16px;
+  max-height: 700px;
+  margin-top: 2rem;
+  overflow-y: auto;
+`;
+
+const StyledRoutineProgress = styled.div`
+  margin: 3rem 0;
+`;
+
+const StyledButton = styled(Button)`
+  position: fixed;
+  bottom: 2rem;
+  z-index: 1000;
+  @media ${Media.sm} {
+    max-width: 150px;
+  }
+  @media ${Media.md} {
+    max-width: 270px;
+  }
+  @media ${Media.lg} {
+    max-width: 270px;
+  }
+`;

--- a/src/stories/pages/RoutineFinishPage.stories.tsx
+++ b/src/stories/pages/RoutineFinishPage.stories.tsx
@@ -1,0 +1,10 @@
+import { RoutineFinishPage } from '@/pages';
+
+export default {
+  title: 'Components/Pages/RoutineFinishPage',
+  component: RoutineFinishPage,
+};
+
+export const Default = (): JSX.Element => {
+  return <RoutineFinishPage />;
+};


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

루틴 요약 페이지 컴포넌트 구현
- closed #114 

## 🧑‍💻 PR 세부 내용

- RoutineProgressModal에서 Modal를 분리하여 컴포넌트를 재사용했습니다
- 일단 미션 완료 타입이 확정되지않아 더미 데이터 타입을 따로 선언해 구현했습니다 
- 미션의 개수가 많을 경우 자동으로 스크롤이 생깁니다
- 종료하기 버튼 클릭 시 나의 루틴 페이지로 이동합니다 

## 📸 스크린샷


https://user-images.githubusercontent.com/77623643/145858970-e2482dc6-b565-49df-bcea-66598946e6b8.mov

<img width="625" alt="무제" src="https://user-images.githubusercontent.com/77623643/145858990-b15a228f-2591-4043-89b9-49a7a49d730f.png">

