### PR TITLE
feat: #119/Page Component - RoutineUpdatePage

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -35,6 +35,7 @@ export { CommentCreator } from './molecules/CommentCreator';
 export type { CommentCreatorProps } from './molecules/CommentCreator';
 export { DaySelector } from './molecules/DaySelector';
 export type { DayItemProps } from './molecules/DaySelector';
+export type { DaySelectorProps } from './molecules/DaySelector';
 export { ColorPalette } from './molecules/ColorPalette';
 export type { ColorPaletteProps } from './molecules/ColorPalette';
 export { Mission } from './molecules/Mission';

--- a/src/components/molecules/ColorPalette/ColorPalette.tsx
+++ b/src/components/molecules/ColorPalette/ColorPalette.tsx
@@ -19,18 +19,13 @@ const ColorPalette = ({
   initialSelectedColor,
   ...props
 }: ColorPaletteProps): JSX.Element => {
-  const [selectedColor, setSelectedColor] = useState<string>(() => {
-    return initialSelectedColor ? initialSelectedColor : '';
-  });
+  const [selectedColor, setSelectedColor] = useState<string>(
+    initialSelectedColor ? initialSelectedColor : '',
+  );
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const color = e.target.value;
-    if (color === selectedColor) {
-      setSelectedColor(color);
-      onChange && onChange(color);
-    } else {
-      setSelectedColor(color);
-      onChange && onChange(color);
-    }
+    setSelectedColor(color);
+    onChange && onChange(color);
   };
   return (
     <StyledColorPalette>

--- a/src/components/molecules/ColorPalette/ColorPalette.tsx
+++ b/src/components/molecules/ColorPalette/ColorPalette.tsx
@@ -1,20 +1,36 @@
 import { Colors, Media } from '@/styles';
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import ColorItem, { ColorItemProps } from './ColorItem';
 import styled from '@emotion/styled';
 
-export interface ColorPaletteProps extends ColorItemProps {
+export interface ColorPaletteProps {
+  color?: Pick<ColorItemProps, 'color'>;
   colors: string[];
+  name: string;
+  onChange: (selectedColor: string) => void;
+  initialSelectedColor?: string;
 }
 
 const ColorPalette = ({
   color,
+  name,
   colors,
   onChange,
+  initialSelectedColor,
   ...props
 }: ColorPaletteProps): JSX.Element => {
+  const [selectedColor, setSelectedColor] = useState<string>(() => {
+    return initialSelectedColor ? initialSelectedColor : '';
+  });
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onChange && onChange(e);
+    const color = e.target.value;
+    if (color === selectedColor) {
+      setSelectedColor(color);
+      onChange && onChange(color);
+    } else {
+      setSelectedColor(color);
+      onChange && onChange(color);
+    }
   };
   return (
     <StyledColorPalette>
@@ -22,8 +38,10 @@ const ColorPalette = ({
         colors.map((color) => (
           <ColorItem
             color={color}
+            name="color"
             onChange={handleChange}
             key={color}
+            checked={selectedColor === color}
             {...props}
           />
         ))}

--- a/src/components/molecules/DaySelector/DayItem.tsx
+++ b/src/components/molecules/DaySelector/DayItem.tsx
@@ -1,9 +1,10 @@
+import { WEEK } from '@/constants';
 import { Colors, FontSize, FontWeight, Media } from '@/styles';
 import styled from '@emotion/styled';
 import React from 'react';
 
 export interface DayItemProps extends React.ComponentProps<'input'> {
-  day?: string;
+  day: string;
 }
 
 const DayItem = ({ day, ...props }: DayItemProps): JSX.Element => {
@@ -17,7 +18,7 @@ const DayItem = ({ day, ...props }: DayItemProps): JSX.Element => {
         {...props}
       />
       <label htmlFor={day}>
-        <StyledDayItem>{day}</StyledDayItem>
+        <StyledDayItem>{WEEK[day]}</StyledDayItem>
       </label>
     </>
   );
@@ -42,10 +43,7 @@ const StyledDayItem = styled.div`
   color: ${Colors.textPrimary};
   font-weight: ${FontWeight.medium};
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
-  :hover {
-    color: ${Colors.textQuaternary};
-    background-color: ${Colors.point};
-  }
+
   @media ${Media.sm} {
     width: 32px;
     height: 32px;

--- a/src/components/molecules/DaySelector/DayItem.tsx
+++ b/src/components/molecules/DaySelector/DayItem.tsx
@@ -62,4 +62,10 @@ const StyledDayItem = styled.div`
     height: 56px;
     font-size: ${FontSize.medium};
   }
+  @media (hover: hover) {
+    :hover {
+      background-color: ${Colors.pointLight};
+      color: ${Colors.textQuaternary};
+    }
+  }
 `;

--- a/src/components/molecules/DaySelector/DaySelector.tsx
+++ b/src/components/molecules/DaySelector/DaySelector.tsx
@@ -15,7 +15,7 @@ const DaySelector = ({
   onChange,
   ...props
 }: DaySelectorProps): JSX.Element => {
-  const days = Object.values(WEEK);
+  const days = Object.keys(WEEK);
   const [selectedDays, setSelctedDays] = useState<string[]>(() => {
     return initialSelectedDays ? initialSelectedDays : [];
   });

--- a/src/components/molecules/DaySelector/DaySelector.tsx
+++ b/src/components/molecules/DaySelector/DaySelector.tsx
@@ -1,18 +1,47 @@
 import { WEEK } from '@/constants';
 import { Media } from '@/styles';
 import styled from '@emotion/styled';
-import { ChangeEvent } from 'react';
-import DayItem, { DayItemProps } from './DayItem';
+import { ChangeEvent, useState } from 'react';
+import DayItem from './DayItem';
 
-const DaySelector = ({ onChange, ...props }: DayItemProps): JSX.Element => {
+export interface DaySelectorProps {
+  name: string;
+  onChange: (selectedDays: string[]) => void;
+  initialSelectedDays?: string[];
+}
+
+const DaySelector = ({
+  initialSelectedDays,
+  onChange,
+  ...props
+}: DaySelectorProps): JSX.Element => {
   const days = Object.values(WEEK);
+  const [selectedDays, setSelctedDays] = useState<string[]>(() => {
+    return initialSelectedDays ? initialSelectedDays : [];
+  });
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onChange && onChange(e);
+    const selectedDay = e.target.value;
+    if (selectedDays?.includes(selectedDay)) {
+      e.target.checked = false;
+      const newSelectedDay = selectedDays.filter((day) => day !== selectedDay);
+      setSelctedDays(newSelectedDay);
+      onChange && onChange(newSelectedDay);
+    } else {
+      const newSelectedDay = [...selectedDays, selectedDay];
+      setSelctedDays(newSelectedDay);
+      onChange && onChange(newSelectedDay);
+    }
   };
   return (
     <StyledDaySelector {...props}>
       {days.map((day) => (
-        <DayItem key={day} onChange={handleChange} day={day} />
+        <DayItem
+          name="weeks"
+          key={day}
+          onChange={handleChange}
+          day={day}
+          checked={selectedDays.includes(day)}
+        />
       ))}
     </StyledDaySelector>
   );

--- a/src/components/molecules/DaySelector/index.ts
+++ b/src/components/molecules/DaySelector/index.ts
@@ -1,2 +1,3 @@
 export { default as DaySelector } from './DaySelector';
 export type { DayItemProps } from './DayItem';
+export type { DaySelectorProps } from './DaySelector';

--- a/src/components/molecules/RoutineCategorySelector/RoutineCategoryItem.tsx
+++ b/src/components/molecules/RoutineCategorySelector/RoutineCategoryItem.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Colors, FontWeight, FontSize, Media } from '@/styles';
 import React from 'react';
+import { ROUTINE_CATEGORY } from '@/constants';
 
 export interface RoutineCategoryItemProps
   extends React.ComponentProps<'input'> {
@@ -21,7 +22,7 @@ const RoutineCategoryItem = ({
         {...props}
       />
       <label htmlFor={category}>
-        <StyledCategoryItem>{category}</StyledCategoryItem>
+        <StyledCategoryItem>{ROUTINE_CATEGORY[category]}</StyledCategoryItem>
       </label>
     </>
   );

--- a/src/components/molecules/RoutineCategorySelector/RoutineCategorySelector.tsx
+++ b/src/components/molecules/RoutineCategorySelector/RoutineCategorySelector.tsx
@@ -24,7 +24,7 @@ const RoutineCategorySelector = ({
   ...props
 }: RoutineCategorySelectorProps): JSX.Element => {
   const [selectedCategories, setSelectedCategories] = useState<string[]>(() => {
-    return type === 'checkbox' ? [] : ['전체'];
+    return type === 'checkbox' ? [] : ['TOTAL'];
   });
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const selectedCategory = e.target.value;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -19,7 +19,7 @@ export const ROUTINE_CATEGORY: ConstantType = Object.freeze({
   STUDY: '공부',
 });
 
-export const WEEK = Object.freeze({
+export const WEEK: ConstantType = Object.freeze({
   MON: '월',
   TUE: '화',
   WED: '수',

--- a/src/pages/myRoutine/RoutineCreatePage.tsx
+++ b/src/pages/myRoutine/RoutineCreatePage.tsx
@@ -56,7 +56,7 @@ const RoutineCreatePage = (): JSX.Element => {
   const handleEmojiChange = (emoji: string) => {
     setRoutine(() => ({ ...routine, emoji }));
   };
-  const handleTitleOrColorChange = (
+  const handleTitleChange = (
     e: ChangeEvent<HTMLInputElement> & {
       name: HTMLInputElement;
       value: HTMLInputElement;
@@ -76,22 +76,18 @@ const RoutineCreatePage = (): JSX.Element => {
     }));
   };
 
-  const handleWeekChange = (
-    e: ChangeEvent<HTMLInputElement> & { target: HTMLInputElement },
-  ) => {
-    const { weeks } = routine;
-    const week = e.target.value;
-    if (weeks) {
-      if (!weeks.includes(week)) {
-        setRoutine((routine) => ({
-          ...routine,
-          weeks: [...weeks, week],
-        }));
-      } else {
-        const newWeek = weeks.filter((item) => item !== week);
-        setRoutine((routine) => ({ ...routine, weeks: newWeek }));
-      }
-    }
+  const handleColorChange = (selectedColor: string) => {
+    setRoutine((routine) => ({
+      ...routine,
+      color: selectedColor,
+    }));
+  };
+
+  const handleWeekChange = (selectedDays: string[]) => {
+    setRoutine((routine) => ({
+      ...routine,
+      weeks: [...selectedDays],
+    }));
   };
 
   const handleTimeChange = (time: any) => {
@@ -120,7 +116,7 @@ const RoutineCreatePage = (): JSX.Element => {
           id="title"
           name="title"
           placeholder="루틴 이름을 입력해주세요"
-          onChange={handleTitleOrColorChange}
+          onChange={handleTitleChange}
         />
         {routine.title ? '' : <Span>루틴 이름을 입력해주세요</Span>}
         <Label htmlFor="routineCategory">카테고리</Label>
@@ -134,7 +130,11 @@ const RoutineCreatePage = (): JSX.Element => {
           />
         </StyledRoutineCategory>
         <Label htmlFor="color">색상</Label>
-        <ColorPalette name="color" onChange={handleTitleOrColorChange} />
+        <ColorPalette
+          name="color"
+          initialSelectedColor={routine.color}
+          onChange={handleColorChange}
+        />
         <Label htmlFor="weeks">요일</Label>
         <DaySelector name="weeks" onChange={handleWeekChange} />
         <Label htmlFor="startGoalTime">시작 시간</Label>

--- a/src/pages/myRoutine/RoutineCreatePage.tsx
+++ b/src/pages/myRoutine/RoutineCreatePage.tsx
@@ -126,7 +126,7 @@ const RoutineCreatePage = (): JSX.Element => {
             type="checkbox"
             name="routineCategory"
             onChange={handleCategoryChange}
-            categories={Object.values(ROUTINE_CATEGORY).slice(1)}
+            categories={Object.keys(ROUTINE_CATEGORY).slice(1)}
           />
         </StyledRoutineCategory>
         <Label htmlFor="color">색상</Label>

--- a/src/pages/myRoutine/RoutineUpdatePage.tsx
+++ b/src/pages/myRoutine/RoutineUpdatePage.tsx
@@ -1,0 +1,112 @@
+import React, { FormEvent, useState } from 'react';
+import { Container, DaySelector, Routine, Button } from '@/components';
+import { Colors, FontSize, Media } from '@/styles';
+import styled from '@emotion/styled';
+import { RoutineType } from '@/Models';
+import Swal from 'sweetalert2';
+import { useHistory } from 'react-router-dom';
+
+const RoutineUpdatePage = (): JSX.Element => {
+  const [selectedRoutine, setSelectedRoutine] = useState<Partial<RoutineType>>({
+    routineId: 1,
+    emoji: '🍿',
+    color: Colors.red,
+    title: '밥먹기',
+    durationGoalTime: 1000,
+    startGoalTime: new Date().toISOString(),
+    routineCategories: ['음식'],
+    weeks: ['월', '수', '금'],
+    missions: [],
+  });
+  const history = useHistory();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    Swal.fire({
+      icon: 'success',
+      title: '루틴 수정이 완료되었습니다!🎉',
+    }).then(() => {
+      history.push('/');
+    });
+  };
+
+  const handleWeekChange = (selectedDays: string[]) => {
+    setSelectedRoutine((selectedRoutine) => ({
+      ...selectedRoutine,
+      weeks: [...selectedDays],
+    }));
+  };
+
+  const onCancelClick = () => {
+    Swal.fire({
+      icon: 'warning',
+      title: '작성했던 모든 내용이 초기화됩니다!',
+    }).then(() => {
+      history.push('/');
+    });
+  };
+  return (
+    <Container style={{ paddingTop: '56px' }}>
+      <Routine
+        routineObject={selectedRoutine}
+        type="create"
+        style={{ marginTop: '3rem' }}
+      />
+      <Form onSubmit={handleSubmit}>
+        <Label htmlFor="weeks">요일</Label>
+        <DaySelector
+          name="weeks"
+          initialSelectedDays={selectedRoutine.weeks}
+          onChange={handleWeekChange}
+        />
+        <Span>루틴은 요일 수정만 가능합니다!</Span>
+        <ButtonContainer>
+          <Button type="button" colorType="white" onClick={onCancelClick}>
+            취소하기
+          </Button>
+          <Button type="submit">수정하기</Button>
+        </ButtonContainer>
+      </Form>
+    </Container>
+  );
+};
+
+export default RoutineUpdatePage;
+
+const Form = styled.form`
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 3rem 0;
+`;
+
+const Label = styled.label`
+  display: inline-block;
+  margin: 2rem 0;
+  font-size: ${FontSize.base};
+  color: ${Colors.textSecondary};
+`;
+
+const Span = styled.span`
+  margin-top: 2rem;
+  color: ${Colors.functionNegative};
+`;
+
+const ButtonContainer = styled.div`
+  margin-top: 5rem;
+  @media ${Media.sm} {
+    > button {
+      width: 100%;
+    }
+  }
+  @media ${Media.md} {
+    display: flex;
+  }
+  @media ${Media.lg} {
+    display: flex;
+  }
+  > button {
+    margin: 0 1rem 1rem 0;
+  }
+`;

--- a/src/pages/myRoutine/RoutineUpdatePage.tsx
+++ b/src/pages/myRoutine/RoutineUpdatePage.tsx
@@ -14,8 +14,8 @@ const RoutineUpdatePage = (): JSX.Element => {
     title: '밥먹기',
     durationGoalTime: 1000,
     startGoalTime: new Date().toISOString(),
-    routineCategories: ['음식'],
-    weeks: ['월', '수', '금'],
+    routineCategories: ['FOOD'],
+    weeks: ['MON', 'WED', 'FRI'],
     missions: [],
   });
   const history = useHistory();
@@ -28,6 +28,7 @@ const RoutineUpdatePage = (): JSX.Element => {
     }).then(() => {
       history.push('/');
     });
+    console.log(selectedRoutine);
   };
 
   const handleWeekChange = (selectedDays: string[]) => {

--- a/src/pages/myRoutine/index.ts
+++ b/src/pages/myRoutine/index.ts
@@ -1,5 +1,6 @@
 export { default as MyRoutinePage } from './MyRoutinePage';
 export { default as RoutineCreatePage } from './RoutineCreatePage';
+export { default as RoutineUpdatePage } from './RoutineUpdatePage';
 export { default as RoutineDetailPage } from './RoutineDetailPage';
 export { default as RoutineFinishPage } from './RoutineFinishPage';
 export { default as RoutineProgressPage } from './RoutineProgressPage';

--- a/src/pages/routineCommunity/RoutineCommunityPage.tsx
+++ b/src/pages/routineCommunity/RoutineCommunityPage.tsx
@@ -21,7 +21,7 @@ const DUMMY_ROUTINE: Partial<RoutineType>[] = [
     title: '집 앞 공원 산책하기',
     durationGoalTime: 10000,
     startGoalTime: `${new Date().toISOString()}`,
-    routineCategories: ['운동'],
+    routineCategories: ['EXERCISE'],
   },
   {
     routineId: 2,
@@ -30,7 +30,7 @@ const DUMMY_ROUTINE: Partial<RoutineType>[] = [
     title: '물 2L 마시기',
     durationGoalTime: 780,
     startGoalTime: `${new Date(2021, 12, 8, 12, 0).toISOString()}`,
-    routineCategories: ['건강'],
+    routineCategories: ['HEALTH'],
   },
   {
     routineId: 3,
@@ -39,7 +39,7 @@ const DUMMY_ROUTINE: Partial<RoutineType>[] = [
     title: '아침 만들어 먹기',
     durationGoalTime: 4200,
     startGoalTime: `${new Date(2021, 12, 8, 6, 30).toISOString()}`,
-    routineCategories: ['음식'],
+    routineCategories: ['FOOD'],
   },
   {
     routineId: 4,
@@ -48,7 +48,7 @@ const DUMMY_ROUTINE: Partial<RoutineType>[] = [
     title: '공부하기',
     durationGoalTime: 1800,
     startGoalTime: `${new Date(2021, 12, 8, 21, 30).toISOString()}`,
-    routineCategories: ['공부'],
+    routineCategories: ['STUDY'],
   },
   {
     routineId: 5,
@@ -57,7 +57,7 @@ const DUMMY_ROUTINE: Partial<RoutineType>[] = [
     title: '공부하기',
     durationGoalTime: 1800,
     startGoalTime: `${new Date(2021, 12, 8, 21, 30).toISOString()}`,
-    routineCategories: ['공부'],
+    routineCategories: ['STUDY'],
   },
   {
     routineId: 6,
@@ -66,7 +66,7 @@ const DUMMY_ROUTINE: Partial<RoutineType>[] = [
     title: '공부하기',
     durationGoalTime: 1800,
     startGoalTime: `${new Date(2021, 12, 8, 21, 30).toISOString()}`,
-    routineCategories: ['공부'],
+    routineCategories: ['STUDY'],
   },
   {
     routineId: 7,
@@ -75,7 +75,7 @@ const DUMMY_ROUTINE: Partial<RoutineType>[] = [
     title: '공부하기',
     durationGoalTime: 1800,
     startGoalTime: `${new Date(2021, 12, 8, 21, 30).toISOString()}`,
-    routineCategories: ['공부'],
+    routineCategories: ['STUDY'],
   },
 
   {
@@ -85,15 +85,14 @@ const DUMMY_ROUTINE: Partial<RoutineType>[] = [
     title: '공부하기',
     durationGoalTime: 1800,
     startGoalTime: `${new Date(2021, 12, 8, 21, 30).toISOString()}`,
-    routineCategories: ['공부'],
+    routineCategories: ['STUDY'],
   },
 ];
 
 const RoutineCommunityPage = (): JSX.Element => {
-  const categoryList = Object.values(ROUTINE_CATEGORY);
-  const [clickedCategory, setClickedCategory] = useState<string>('전체');
+  const [clickedCategory, setClickedCategory] = useState<string[]>(['TOTAL']);
   const categoryChangeHandler = (category: string[]) => {
-    setClickedCategory(category[0]);
+    setClickedCategory(category);
   };
 
   const history = useHistory();
@@ -120,12 +119,12 @@ const RoutineCommunityPage = (): JSX.Element => {
               type="radio"
               selectedLimit={1}
               onChange={categoryChangeHandler}
-              categories={categoryList}
+              categories={Object.keys(ROUTINE_CATEGORY)}
             />
           </CategoryContainer>
           <RoutineGridBox>
             {DUMMY_ROUTINE?.map((routine) => {
-              if (clickedCategory === '전체') {
+              if (clickedCategory[0] === 'TOTAL') {
                 return (
                   <Routine
                     onClick={(e) => onClickRoutine(e, routine.routineId)}
@@ -134,7 +133,9 @@ const RoutineCommunityPage = (): JSX.Element => {
                     type="communityRoutine"
                   />
                 );
-              } else if (routine.routineCategories?.includes(clickedCategory)) {
+              } else if (
+                routine.routineCategories?.includes(clickedCategory[0])
+              ) {
                 return (
                   <Routine
                     onClick={(e) => onClickRoutine(e, routine.routineId)}
@@ -154,12 +155,12 @@ const RoutineCommunityPage = (): JSX.Element => {
               type="radio"
               selectedLimit={1}
               onChange={categoryChangeHandler}
-              categories={categoryList}
+              categories={Object.keys(ROUTINE_CATEGORY)}
             />
           </CategoryContainer>
           <RoutineGridBox>
             {DUMMY_ROUTINE?.map((routine) => {
-              if (clickedCategory === '전체') {
+              if (clickedCategory[0] === 'TOTAL') {
                 return (
                   <Routine
                     onClick={(e) => onClickRoutine(e, routine.routineId)}
@@ -169,7 +170,9 @@ const RoutineCommunityPage = (): JSX.Element => {
                     like={routine.routineId}
                   />
                 );
-              } else if (routine.routineCategories?.includes(clickedCategory)) {
+              } else if (
+                routine.routineCategories?.includes(clickedCategory[0])
+              ) {
                 return (
                   <Routine
                     onClick={(e) => onClickRoutine(e, routine.routineId)}
@@ -190,12 +193,12 @@ const RoutineCommunityPage = (): JSX.Element => {
               type="radio"
               selectedLimit={1}
               onChange={categoryChangeHandler}
-              categories={categoryList}
+              categories={Object.keys(ROUTINE_CATEGORY)}
             />
           </CategoryContainer>
           <RoutineGridBox>
             {DUMMY_ROUTINE?.map((routine) => {
-              if (clickedCategory === '전체') {
+              if (clickedCategory[0] === 'TOTAL') {
                 return (
                   <Routine
                     onClick={(e) => onClickRoutine(e, routine.routineId)}
@@ -204,7 +207,9 @@ const RoutineCommunityPage = (): JSX.Element => {
                     type="communityMyRoutine"
                   />
                 );
-              } else if (routine.routineCategories?.includes(clickedCategory)) {
+              } else if (
+                routine.routineCategories?.includes(clickedCategory[0])
+              ) {
                 return (
                   <Routine
                     onClick={(e) => onClickRoutine(e, routine.routineId)}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -18,6 +18,7 @@ import {
   AnalysisPage,
   NotFoundPage,
 } from '@/pages';
+import { RoutineUpdatePage } from '@/pages/myRoutine';
 
 const Router = (): JSX.Element => {
   return (
@@ -26,7 +27,7 @@ const Router = (): JSX.Element => {
       <Route path="/routine" exact component={MyRoutinePage} />
       <Route path="/routine/create" exact component={RoutineCreatePage} />
       <Route path="/routine/:id" exact component={RoutineDetailPage} />
-      <Route path="/routine/:id/update" exact component={RoutineCreatePage} />
+      <Route path="/routine/:id/update" exact component={RoutineUpdatePage} />
       <Route path="/routine/:id/create" exact component={MissionCreatePage} />
       <Route
         path="/routine/:id/progress"

--- a/src/stories/components/molecules/DaySelector.stories.tsx
+++ b/src/stories/components/molecules/DaySelector.stories.tsx
@@ -1,4 +1,4 @@
-import { DayItemProps, DaySelector } from '@/components';
+import { DaySelector, DaySelectorProps } from '@/components';
 
 export default {
   title: 'Components/Molecules/DaySelector',
@@ -8,6 +8,6 @@ export default {
   },
 };
 
-export const Default = ({ ...args }: DayItemProps): JSX.Element => {
+export const Default = ({ ...args }: DaySelectorProps): JSX.Element => {
   return <DaySelector {...args} />;
 };

--- a/src/stories/pages/RoutineUpdatePage.stories.tsx
+++ b/src/stories/pages/RoutineUpdatePage.stories.tsx
@@ -1,0 +1,10 @@
+import { RoutineUpdatePage } from '@/pages/myRoutine';
+
+export default {
+  title: 'Components/Pages/RoutineUpdatePage',
+  component: RoutineUpdatePage,
+};
+
+export const Default = (): JSX.Element => {
+  return <RoutineUpdatePage />;
+};


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

루틴 수정 페이지 컴포넌트 구현
- closed #119 

## 🧑‍💻 PR 세부 내용

- 루틴 수정은 요일만 가능하도록 설정했습니다
- 기존 루틴이 가지고 있는 요일이 체크된 상태로 페이지가 렌더링됩니다
- 취소하기와 수정하기 클릭 시 나의 루틴 페이지로 이동합니다 
- 수정 페이지를 구현하면서 부득이하게 DaySelector, ColorPalette를 수정하게됐습니다 :(

### 논의 사항
- 요일을 확인할 수 있는 페이지가 없어서, 수정 반영되는게 가시적으로 확인되지 않는 것 같아요!
  루틴에도 요일을 추가하는데 어떨까 싶습니다.... 

## 📸 스크린샷

https://user-images.githubusercontent.com/77623643/145975056-4c4d7e15-6664-4b6b-b17e-43ae9b1cd46c.mov


