### PR TITLE
refactor: #116/Template Component - Container

### DIFF
--- a/src/components/templates/Container/Container.tsx
+++ b/src/components/templates/Container/Container.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { Media } from '@/styles';
-import { NavBar, Header, IconButton } from '@/components';
+import { NavBar, Header } from '@/components';
 
 export interface ContainerProps extends React.ComponentProps<'div'> {
   navBar?: boolean;
@@ -14,9 +14,7 @@ const Container = ({
 }: ContainerProps): JSX.Element => {
   return (
     <AppContainer>
-      <Header>
-        <IconButton.UserProfile />
-      </Header>
+      <Header />
       <ContentContainer {...props}>{children}</ContentContainer>
       {navBar && <NavBar />}
     </AppContainer>
@@ -54,7 +52,7 @@ const ContentContainer = styled.div`
   align-items: center;
   width: 100%;
   height: 100%;
-  padding-top: 40px;
+  padding-top: 60px;
 
   @media ${Media.sm} {
     padding-bottom: 56px;

--- a/src/components/templates/Header/Header.tsx
+++ b/src/components/templates/Header/Header.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import { useRouteMatch, useHistory } from 'react-router-dom';
 import { IconButton, IconButtonProps } from '@/components';
+import { Avatar } from '@mui/material';
+import { Media, Colors } from '@/styles';
 
 export type HeaderProps = React.ComponentProps<'header'>;
 
@@ -12,7 +14,12 @@ const Header = ({ ...props }: HeaderProps): JSX.Element => {
     <Container {...props}>
       <ContentContainer>
         <BackButton visible={params.length > 1 && history.length > 1} />
-        <IconButton.UserProfile />
+        <StyledAvatar
+          on={params[0] === 'mypage' ? 1 : 0}
+          onClick={() => {
+            history.push('/mypage');
+          }}
+        />
       </ContentContainer>
     </Container>
   );
@@ -25,15 +32,28 @@ const Container = styled.header`
   position: fixed;
   align-items: center;
   width: 100%;
-  height: 40px;
+  max-width: 768px;
   background-color: white;
-  z-index: 1;
+  z-index: 100;
+
+  @media ${Media.sm} {
+    padding: 0 15px;
+  }
+  @media ${Media.md} {
+    padding: 0 40px;
+  }
+  @media ${Media.lg} {
+    padding: 0 40px;
+  }
 `;
 
 const ContentContainer = styled.div`
   display: flex;
   justify-content: space-between;
-  max-width: 768px;
+  align-items: center;
+  /* max-width: 768px; */
+  width: 100%;
+  height: 60px;
   margin: 0 auto;
 `;
 
@@ -41,6 +61,34 @@ const BackButton = styled(IconButton.Back)<
   IconButtonProps & { visible: boolean }
 >`
   visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
+`;
+
+const StyledAvatar = styled(Avatar)<{ on: number }>`
+  background-color: ${({ on }) => (on ? Colors.point : Colors.pointLight)};
+  cursor: pointer;
+
+  @media (hover: hover) {
+    &:hover {
+      background-color: ${Colors.backgroundButton};
+    }
+  }
+
+  &:active {
+    background-color: ${Colors.point};
+  }
+
+  @media ${Media.sm} {
+    width: 32px;
+    height: 32px;
+  }
+  @media ${Media.md} {
+    width: 40px;
+    height: 40px;
+  }
+  @media ${Media.lg} {
+    width: 40px;
+    height: 40px;
+  }s
 `;
 
 export default Header;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

Container 컴포넌트 리팩토링

- closed #116 

## 🧑‍💻 PR 세부 내용

#### 🚧 변경사항
- 헤더의 레이아웃이 자여스러운 위치에 있도록 수정하였습니다.
- mui의 Avatar 컴포넌트로 대체하였습니다.
- 마이페이지 접근시 액티브 컬러를 주어 현재 위치를 인지할 수 있도록 하였습니다.

> 혹시 또 변경되거나 추가 되었으면 하는 기능 있으시면 말씀해주세요! 🙏🏻

## 📸 스크린샷


https://user-images.githubusercontent.com/41064875/145989967-f900ddb3-fee3-4076-84da-e43e49e3bb13.mov


