### PR TITLE
refactor: #128/API - RoutineUpdatePage

### DIFF
--- a/src/components/molecules/DaySelector/DaySelector.tsx
+++ b/src/components/molecules/DaySelector/DaySelector.tsx
@@ -21,15 +21,28 @@ const DaySelector = ({
   });
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const selectedDay = e.target.value;
-    if (selectedDays?.includes(selectedDay)) {
+    if (initialSelectedDays?.includes(selectedDay)) {
+      e.target.checked = false;
+      const newSelectedDay = initialSelectedDays.filter(
+        (day) => day !== selectedDay,
+      );
+      setSelctedDays(newSelectedDay);
+      onChange && onChange(newSelectedDay);
+    } else if (selectedDays?.includes(selectedDay)) {
       e.target.checked = false;
       const newSelectedDay = selectedDays.filter((day) => day !== selectedDay);
       setSelctedDays(newSelectedDay);
       onChange && onChange(newSelectedDay);
     } else {
-      const newSelectedDay = [...selectedDays, selectedDay];
-      setSelctedDays(newSelectedDay);
-      onChange && onChange(newSelectedDay);
+      if (initialSelectedDays) {
+        const newSelectedDay = [...initialSelectedDays, selectedDay];
+        setSelctedDays(newSelectedDay);
+        onChange && onChange(newSelectedDay);
+      } else {
+        const newSelectedDay = [...selectedDays, selectedDay];
+        setSelctedDays(newSelectedDay);
+        onChange && onChange(newSelectedDay);
+      }
     }
   };
   return (
@@ -40,7 +53,11 @@ const DaySelector = ({
           key={day}
           onChange={handleChange}
           day={day}
-          checked={selectedDays.includes(day)}
+          checked={
+            initialSelectedDays
+              ? initialSelectedDays.includes(day)
+              : selectedDays.includes(day)
+          }
         />
       ))}
     </StyledDaySelector>

--- a/src/components/molecules/Routine/Routine.tsx
+++ b/src/components/molecules/Routine/Routine.tsx
@@ -119,7 +119,7 @@ const Routine = ({
       <Title>{name ? name : '\u00A0'}</Title>
       <TotalTime>{durationTime ? durationTime : '\u00A0'}</TotalTime>
       <Weeks>
-        {type === 'myRoutine' ? `${convertWeeks(weeks)}` : '\u00A0'}
+        {type === 'myRoutine' || 'create' ? `${convertWeeks(weeks)}` : '\u00A0'}
       </Weeks>
       <StartTime>{startTime ? startTime : '\u00A0'}</StartTime>
     </RoutineContainer>

--- a/src/pages/myRoutine/RoutineCreatePage.tsx
+++ b/src/pages/myRoutine/RoutineCreatePage.tsx
@@ -15,7 +15,7 @@ import styled from '@emotion/styled';
 import moment from 'moment';
 import { RoutineType } from '@/Models';
 import Swal from 'sweetalert2';
-import { ROUTINE_CATEGORY } from '@/constants';
+import { ROUTINE_CATEGORY, WEEK } from '@/constants';
 import { useHistory } from 'react-router-dom';
 import { routineApi } from '@/apis';
 
@@ -32,8 +32,9 @@ const RoutineCreatePage = (): JSX.Element => {
     routineCategory: [],
     weeks: [],
   });
-
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    const defaultWeeks = Object.keys(WEEK);
+    console.log(routine);
     e.preventDefault();
     const { name, routineCategory } = routine;
     if (!name) {
@@ -48,7 +49,10 @@ const RoutineCreatePage = (): JSX.Element => {
       });
     } else {
       try {
-        await routineApi.createRoutine(routine);
+        await routineApi.createRoutine({
+          ...routine,
+          weeks: routine.weeks.length !== 0 ? routine.weeks : defaultWeeks,
+        });
         Swal.fire({
           icon: 'success',
           title: '루틴 생성이 완료되었습니다!🎉',
@@ -96,6 +100,7 @@ const RoutineCreatePage = (): JSX.Element => {
   };
 
   const handleWeekChange = (selectedDays: string[]) => {
+    console.log(selectedDays);
     setRoutine((routine) => ({
       ...routine,
       weeks: [...selectedDays],


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

루틴 수정 페이지 API 연동
- closed #128 

## 🧑‍💻 PR 세부 내용

- 루틴 수정 API 연동 및 수정 반영 확인했습니다
- 루틴 수정 클릭 시 해당 루틴에 해당하는 정보들이 렌더링 되고, 지정한 요일 역시 체크된 상태로 유지됩니다

## 📸 스크린샷

https://user-images.githubusercontent.com/77623643/146508775-f502b623-4aa6-46be-8faa-091dab21435c.mov


