### PR TITLE
refactor: #150/API - RoutineProgressPage

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -3,3 +3,4 @@ export { default as routineApi } from './routine';
 export { default as missionApi } from './mission';
 export { default as postApi } from './post';
 export { default as commentApi } from './comment';
+export { default as missionStatusApi } from './mission-status';

--- a/src/apis/mission-status.ts
+++ b/src/apis/mission-status.ts
@@ -1,0 +1,31 @@
+// import { request, authRequest } from './config';
+
+import { AxiosResponse } from 'axios';
+import { authRequest } from './config';
+
+interface MissionStatusApiType {
+  createMissionStatus: (routineId: number) => Promise<AxiosResponse>;
+  updateMissionStatus: (
+    routineId: number,
+    missionInfo: {
+      routineStatusId: number;
+      missionStatusId: number;
+      orders: number;
+      startTime?: string;
+      endTime?: string;
+      userDurationTime?: number;
+    },
+  ) => Promise<AxiosResponse>;
+  getMissionStatus: (missionId: number) => Promise<AxiosResponse>;
+}
+
+const missionStatusApi: MissionStatusApiType = {
+  createMissionStatus: (routineId) =>
+    authRequest.post(`/routines/${routineId}/mission-status`),
+  updateMissionStatus: (routineId, missionInfo) =>
+    authRequest.put(`/routines/${routineId}/mission-status`, missionInfo),
+  getMissionStatus: (routineId) =>
+    authRequest.get(`/routines/${routineId}/mission-status`),
+};
+
+export default missionStatusApi;

--- a/src/apis/mission-status.ts
+++ b/src/apis/mission-status.ts
@@ -16,7 +16,7 @@ interface MissionStatusApiType {
       userDurationTime?: number;
     },
   ) => Promise<AxiosResponse>;
-  getMissionStatus: (missionId: number) => Promise<AxiosResponse>;
+  getMissionStatus: (routineId: number) => Promise<AxiosResponse>;
 }
 
 const missionStatusApi: MissionStatusApiType = {

--- a/src/apis/mission.ts
+++ b/src/apis/mission.ts
@@ -20,7 +20,10 @@ interface MissionApiType {
       missionOrders: { missionId: number; orders: number }[];
     },
   ) => Promise<AxiosResponse>;
-  deleteMission: (missionId: number) => Promise<AxiosResponse>;
+  deleteMission: (
+    routindId: number,
+    missionId: number,
+  ) => Promise<AxiosResponse>;
 }
 
 const missionApi: MissionApiType = {
@@ -28,8 +31,8 @@ const missionApi: MissionApiType = {
     authRequest.post(`/routines/${routineId}/missions`, missionInfo),
   updateMission: (routineId, missionInfo) =>
     authRequest.put(`/routines/${routineId}/missions`, missionInfo),
-  deleteMission: (missionId) =>
-    authRequest.delete(`/routines/missions/${missionId}`),
+  deleteMission: (routindId, missionId) =>
+    authRequest.delete(`/routines/${routindId}/missions/${missionId}`),
 };
 
 export default missionApi;

--- a/src/components/organisms/RoutineProgressModal/RoutineProgress.tsx
+++ b/src/components/organisms/RoutineProgressModal/RoutineProgress.tsx
@@ -39,7 +39,7 @@ const RoutineProgressModal = ({
                     ? TimeUtils.calculateTime(durationGoalTime)
                     : TimeUtils.calculateTime(userDurationTime || 0)}
                 </DurationTime>
-                {userDurationTime ? (
+                {userDurationTime || userDurationTime === 0 ? (
                   <UserDurationTime
                     style={{
                       color:
@@ -50,7 +50,9 @@ const RoutineProgressModal = ({
                           : `${Colors.functionPositive}`,
                     }}
                   >
-                    {durationGoalTime < userDurationTime
+                    {userDurationTime === 0
+                      ? '(-'
+                      : durationGoalTime < durationGoalTime - userDurationTime
                       ? '(+'
                       : durationGoalTime === userDurationTime
                       ? '('

--- a/src/components/organisms/RoutineProgressModal/RoutineProgressModal.tsx
+++ b/src/components/organisms/RoutineProgressModal/RoutineProgressModal.tsx
@@ -43,7 +43,7 @@ const RoutineProgressModal = ({
                       ? TimeUtils.calculateTime(durationGoalTime)
                       : TimeUtils.calculateTime(userDurationTime || 0)}
                   </DurationTime>
-                  {userDurationTime ? (
+                  {userDurationTime || userDurationTime === 0 ? (
                     <UserDurationTime
                       style={{
                         color:
@@ -54,7 +54,9 @@ const RoutineProgressModal = ({
                             : `${Colors.functionPositive}`,
                       }}
                     >
-                      {durationGoalTime < durationGoalTime - userDurationTime
+                      {userDurationTime === 0
+                        ? '(-'
+                        : durationGoalTime < durationGoalTime - userDurationTime
                         ? '(+'
                         : durationGoalTime ===
                           durationGoalTime - userDurationTime

--- a/src/pages/myRoutine/MyRoutinePage.tsx
+++ b/src/pages/myRoutine/MyRoutinePage.tsx
@@ -47,7 +47,6 @@ const MyRoutinePage = (): JSX.Element => {
       if (result.isConfirmed) {
         try {
           await routineApi.deleteRoutine(routineId);
-
           Swal.fire({
             position: 'center',
             icon: 'success',
@@ -62,7 +61,7 @@ const MyRoutinePage = (): JSX.Element => {
           Swal.fire({
             icon: 'error',
             title: '이런',
-            text: '미션이 삭제되지 않았어요!',
+            text: '에러로 인해 루틴이 삭제되지 않았어요!',
           });
         }
       }

--- a/src/pages/myRoutine/RoutineDetailPage.tsx
+++ b/src/pages/myRoutine/RoutineDetailPage.tsx
@@ -85,7 +85,7 @@ const RoutineDetailPage = (): JSX.Element => {
     }).then(async (result) => {
       if (result.isConfirmed) {
         try {
-          await missionApi.deleteMission(mission.missionId);
+          await missionApi.deleteMission(routineId, mission.missionId);
           await getRoutineDetail();
 
           Swal.fire({

--- a/src/pages/myRoutine/RoutineProgressPage.tsx
+++ b/src/pages/myRoutine/RoutineProgressPage.tsx
@@ -31,7 +31,6 @@ const RoutineProgressPage = (): JSX.Element => {
   const [routine, setRoutine] = useState<any>({});
   const [missions, setMissions] = useState<any>([]);
   const [currentMissions, setCurrentMissions] = useState<any>({});
-  const [missionStatusIds, setMissionStatusIds] = useState<any>([]);
   const [routineStatusId, setRoutineStatusId] = useState(0);
   const params: { id: string } = useParams();
   const routineId = +params['id'];
@@ -58,7 +57,6 @@ const RoutineProgressPage = (): JSX.Element => {
         routineStatusId: number;
       } = await createRoutineProgress();
 
-      setMissionStatusIds(missionMissionStatusIds);
       setRoutineStatusId(routineStatusId);
 
       const result = await routineApi.getRoutine(routineId);
@@ -91,34 +89,39 @@ const RoutineProgressPage = (): JSX.Element => {
     }
   };
 
-  const startMission = async () => {
+  const startMission = async (currentMission: {
+    missionStatusId: number;
+    orders: number;
+  }) => {
     try {
       const missionStatus = {
         routineStatusId: routineStatusId,
-        missionStatusId: currentMissions['missionStatusId'],
-        orders: currentMissions['orders'],
+        missionStatusId: currentMission['missionStatusId'],
+        orders: currentMission['orders'],
         startTime: moment().toISOString(),
+        userDurationTime: 0,
       };
-      console.log(missionStatus);
-      console.log(currentMissions);
       await missionStatusApi.updateMissionStatus(routineId, missionStatus);
     } catch (e) {
-      console.error(e);
+      console.error('startMission: ', e);
     }
   };
 
-  const startPrevMission = async () => {
+  const startPrevMission = async (currentMission: {
+    missionStatusId: number;
+    orders: number;
+  }) => {
     try {
       const missionStatus = {
         routineStatusId: routineStatusId,
-        missionStatusId: currentMissions['missionStatusId'],
-        orders: currentMissions['orders'],
+        missionStatusId: currentMission['missionStatusId'],
+        orders: currentMission['orders'],
         startTime: moment().toISOString(),
-        endTime: moment().toISOString(),
+        userDurationTime: 0,
       };
       await missionStatusApi.updateMissionStatus(routineId, missionStatus);
     } catch (e) {
-      console.error(e);
+      console.error('startPrevMission: ', e);
     }
   };
 
@@ -133,7 +136,7 @@ const RoutineProgressPage = (): JSX.Element => {
       };
       await missionStatusApi.updateMissionStatus(routineId, missionStatus);
     } catch (e) {
-      console.error(e);
+      console.error('endMission: ', e);
     }
   };
 
@@ -194,10 +197,10 @@ const RoutineProgressPage = (): JSX.Element => {
 
         setProgress((prevProgress: any) => {
           const nextState = prevProgress.map((progress: any, index: number) => {
-            if (index === currentIndex) {
+            if (index === currentIndex - 1) {
               return {
                 ...progress,
-                isPassed: false,
+                isPassed: undefined,
                 userDurationTime: null,
               };
             }
@@ -220,7 +223,7 @@ const RoutineProgressPage = (): JSX.Element => {
         await sleep(450);
         setPrevStep(false);
 
-        await startPrevMission();
+        await startPrevMission(missions[currentIndex - 1]);
       }
     });
   };
@@ -274,7 +277,7 @@ const RoutineProgressPage = (): JSX.Element => {
         await sleep(450);
         setNextStep(false);
 
-        await startMission();
+        await startMission(missions[currentIndex + 1]);
       }
     });
   };
@@ -334,7 +337,7 @@ const RoutineProgressPage = (): JSX.Element => {
     await sleep(450);
     setNextStep(false);
 
-    await startMission();
+    await startMission(missions[currentIndex + 1]);
   };
 
   const ProgressModalEmement = useMemo(() => {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -26,7 +26,8 @@ const calculateTime = (time: number | string): string | null => {
 };
 
 const formatStartTime = (time: string): string => {
-  return moment(time).format('LT');
+  const t = time.includes('Z') ? time : time + 'Z';
+  return moment(t).format('LT');
 };
 
 const dateFromNow = (time: string): string => {


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

RoutineProgressPage - API 연결
- closed #150 

## 🧑‍💻 PR 세부 내용

- 루틴을 시작했을 때 `mission-status` 생성 API 호출 추가했습니다.
- 각 미션이 시작될 때, 끝날 때 `mission-status` 수정 API 호출 추가했습니다.
- 만약 미션을 `pass`했을 때, 끝났을 때 보내는 수정 API는 호출하지 않습니다.(endTime, userDuration 항목 null)
- 만약 이전 미션으로 되돌아갔을 때 startTime은 재설정, userDurationTime값은 0으로 초기화하여 API를 호출합니다.

## 📸 스크린샷

https://user-images.githubusercontent.com/85148549/146665550-85ad9226-e0c8-4207-9922-3f1be9937744.mp4

