### PR TITLE
refactor: #159/API - RoutineFinishPage

### DIFF
--- a/src/components/organisms/RoutineProgressModal/RoutineProgress.tsx
+++ b/src/components/organisms/RoutineProgressModal/RoutineProgress.tsx
@@ -17,7 +17,7 @@ export interface RoutineProgressProps extends React.ComponentProps<'div'> {
 
 const RoutineProgressModal = ({
   missionObject,
-}: RoutineProgressProps): JSX.Element => {
+}: Partial<RoutineProgressProps>): JSX.Element => {
   return (
     <Fragment>
       {missionObject?.map(

--- a/src/components/organisms/RoutineProgressModal/RoutineProgressModal.tsx
+++ b/src/components/organisms/RoutineProgressModal/RoutineProgressModal.tsx
@@ -63,7 +63,7 @@ const RoutineProgressModal = ({
                         ? '('
                         : '(-'}
                       {TimeUtils.calculateTime(
-                        durationGoalTime - userDurationTime,
+                        Math.abs(durationGoalTime - userDurationTime),
                       ) + ')'}
                     </UserDurationTime>
                   ) : isPassed ? (

--- a/src/pages/myRoutine/MyRoutinePage.tsx
+++ b/src/pages/myRoutine/MyRoutinePage.tsx
@@ -21,8 +21,16 @@ const MyRoutinePage = (): JSX.Element => {
     const finishedRoutines = await routineApi.getFinishedRoutines();
     const notFinishedRoutines = await routineApi.getNotFinishedRoutines();
 
+    const finishedRoutineIds = finishedRoutines.data.data.map(
+      (routine: { routineId: number }) => routine.routineId,
+    );
+    const allRoutinesExceptFinished = routines.data.data.filter(
+      (routine: { routineId: number }) =>
+        !finishedRoutineIds.includes(routine.routineId),
+    );
+
     setRoutines({
-      all: routines.data.data,
+      all: allRoutinesExceptFinished,
       finish: finishedRoutines.data.data,
       notFinish: notFinishedRoutines.data.data,
     });
@@ -93,21 +101,38 @@ const MyRoutinePage = (): JSX.Element => {
           {token ? (
             routines.all.length !== 0 ? (
               <RoutineGridBox>
-                {routines.all?.map((routine) => (
-                  <Routine
-                    onClick={(e) => onClickRoutine(e, routine['routineId'])}
-                    key={routine['routineId']}
-                    routineObject={routine}
-                    type="myRoutine"
-                    completed={false}
-                    deleteRoutine={() => {
-                      deleteRoutine(routine);
-                    }}
-                    updateRoutine={() => {
-                      onClickUpdateRoutine(routine['routineId']);
-                    }}
-                  />
-                ))}
+                {routines.all &&
+                  routines.all?.map((routine) => (
+                    <Routine
+                      onClick={(e) => onClickRoutine(e, routine['routineId'])}
+                      key={routine['routineId']}
+                      routineObject={routine}
+                      type="myRoutine"
+                      completed={false}
+                      deleteRoutine={() => {
+                        deleteRoutine(routine);
+                      }}
+                      updateRoutine={() => {
+                        onClickUpdateRoutine(routine['routineId']);
+                      }}
+                    />
+                  ))}
+                {routines.finish &&
+                  routines.finish?.map((routine) => (
+                    <Routine
+                      onClick={(e) => onClickRoutine(e, routine['routineId'])}
+                      key={routine['routineId']}
+                      routineObject={routine}
+                      type="myRoutine"
+                      completed={true}
+                      deleteRoutine={() => {
+                        deleteRoutine(routine);
+                      }}
+                      updateRoutine={() => {
+                        onClickUpdateRoutine(routine['routineId']);
+                      }}
+                    />
+                  ))}
               </RoutineGridBox>
             ) : (
               <MessageContainer>

--- a/src/pages/myRoutine/RoutineDetailPage.tsx
+++ b/src/pages/myRoutine/RoutineDetailPage.tsx
@@ -35,6 +35,7 @@ const RoutineDetailPage = (): JSX.Element => {
   const [missions, setMissions] = useState<any>([]);
   const [isFinished, setIsFinished] = useState(false);
   const [missionIsEmpty, setMissionIsEmpty] = useState(false);
+  const [isTodayRoutine, setIsTodayRoutine] = useState(false);
   const history = useHistory();
 
   const updateMission = useCallback(async () => {
@@ -84,13 +85,22 @@ const RoutineDetailPage = (): JSX.Element => {
     }
   };
 
-  const getFinishedRoutines = async () => {
+  const getMyRoutines = async () => {
     const finishedRoutines = await routineApi.getFinishedRoutines();
+    const notFinishedRoutines = await routineApi.getNotFinishedRoutines();
+
     const finishedRoutineIds = finishedRoutines.data.data.map(
       (routine: { routineId: number }) => routine.routineId,
     );
+    const notFinishedRoutineIds = notFinishedRoutines.data.data.map(
+      (routine: { routineId: number }) => routine.routineId,
+    );
+
     if (finishedRoutineIds.includes(routineId)) {
       setIsFinished(true);
+    }
+    if (notFinishedRoutineIds.includes(routineId)) {
+      setIsTodayRoutine(true);
     }
   };
 
@@ -132,7 +142,7 @@ const RoutineDetailPage = (): JSX.Element => {
 
   useEffect(() => {
     getRoutineDetail();
-    getFinishedRoutines();
+    getMyRoutines();
     // eslint-disable-next-line
   }, []);
 
@@ -156,7 +166,17 @@ const RoutineDetailPage = (): JSX.Element => {
       Swal.fire({
         position: 'center',
         icon: 'warning',
-        title: '미션을 생성해주세요',
+        title: '미션이 없어요!',
+        text: '미션을 생성해주세요',
+        showConfirmButton: false,
+        timer: 2000,
+      });
+    } else if (!isTodayRoutine) {
+      Swal.fire({
+        position: 'center',
+        icon: 'warning',
+        title: '오늘 수행 가능한 루틴이 아니에요',
+        text: `${routine.name}의 요일을 확인해주세요`,
         showConfirmButton: false,
         timer: 2000,
       });

--- a/src/pages/myRoutine/RoutineFinishPage.tsx
+++ b/src/pages/myRoutine/RoutineFinishPage.tsx
@@ -1,96 +1,84 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Container, RoutineInfo, RoutineProgress } from '@/components';
 import { Colors, FontSize, FontWeight, Media } from '@/styles';
 import styled from '@emotion/styled';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
+import { missionStatusApi, routineApi } from '@/apis';
+import moment from 'moment';
+
+interface RoutineInfoType {
+  emoji: string;
+  name: string;
+  durationGoalTime: number;
+}
 
 const RoutineFinishPage = (): JSX.Element => {
   const history = useHistory();
-  const routineDummy = {
-    emoji: '💪',
-    name: '한강에서 산책하기',
-    durationGoalTime: 12345,
+  const params = useParams();
+  const routineId = params['id'] && +params['id'];
+  const [todayMissionStatus, setTodayMissionStatus] = useState<any>([]);
+  const [routineInfo, setRoutineInfo] = useState<any>([]);
+
+  const getFinishedRoutineDetail = async () => {
+    if (!routineId) return;
+    try {
+      const result = await missionStatusApi.getMissionStatus(routineId);
+      const missionStatus = result.data.data
+        ?.filter(
+          (status: { missionStatusDetailResponse: { startTime: string } }) =>
+            moment(status.missionStatusDetailResponse.startTime).days() === 0,
+        )
+        .map(
+          (status: {
+            missionStatusDetailResponse: {
+              userDurationTime: number;
+              endTime: string | null;
+            };
+          }) => {
+            const { userDurationTime, endTime } =
+              status.missionStatusDetailResponse;
+
+            return {
+              ...status,
+              userDurationTime: endTime === null ? null : userDurationTime,
+              isPassed: endTime === null ? true : false,
+            };
+          },
+        );
+      setTodayMissionStatus(missionStatus);
+    } catch (e) {
+      console.error('getFinishedRoutineDetail: ', e);
+    }
   };
-  const missionCompletionDummy: {
-    missionId: number;
-    emoji: string;
-    name: string;
-    durationGoalTime: number;
-    color: string;
-    userDurationTime: number;
-  }[] = [
-    {
-      missionId: 10,
-      emoji: '🚿',
-      name: '샤워하기',
-      durationGoalTime: 1200,
-      color: Colors.red,
-      userDurationTime: 1500,
-    },
-    {
-      missionId: 11,
-      emoji: '🪥',
-      name: '양치하기',
-      durationGoalTime: 1200,
-      color: Colors.red,
-      userDurationTime: 1000,
-    },
-    {
-      missionId: 12,
-      emoji: '📝',
-      name: '공부하기',
-      durationGoalTime: 1200,
-      color: Colors.red,
-      userDurationTime: 500,
-    },
-    {
-      missionId: 13,
-      emoji: '🥗',
-      name: '밥먹기',
-      durationGoalTime: 1200,
-      color: Colors.red,
-      userDurationTime: 2500,
-    },
-    {
-      missionId: 14,
-      emoji: '📔',
-      name: '독서하기',
-      durationGoalTime: 1200,
-      color: Colors.red,
-      userDurationTime: 1200,
-    },
-    {
-      missionId: 15,
-      emoji: '📚',
-      name: '공부하기',
-      durationGoalTime: 1200,
-      color: Colors.red,
-      userDurationTime: 500,
-    },
-    {
-      missionId: 16,
-      emoji: '🎂',
-      name: '밥먹기',
-      durationGoalTime: 1200,
-      color: Colors.red,
-      userDurationTime: 2500,
-    },
-    {
-      missionId: 17,
-      emoji: '📋',
-      name: '독서하기',
-      durationGoalTime: 1200,
-      color: Colors.red,
-      userDurationTime: 1200,
-    },
-  ];
+
+  const getRoutineInfo = async () => {
+    if (!routineId) return;
+    try {
+      const result = await routineApi.getRoutine(routineId);
+      const routineInfo: RoutineInfoType = {
+        emoji: result.data.data.emoji,
+        name: result.data.data.name,
+        durationGoalTime: result.data.data.durationGoalTime,
+      };
+      setRoutineInfo(routineInfo);
+    } catch (e) {
+      console.error('getRoutineInfo: ', e);
+    }
+  };
+
+  useEffect(() => {
+    getFinishedRoutineDetail();
+    getRoutineInfo();
+    // eslint-disable-next-line
+  }, []);
+
   return (
     <Container>
       <Title>루틴 요약</Title>
-      <RoutineInfo routineObject={routineDummy} />
+      <RoutineInfo routineObject={routineInfo} />
       <RoutineProgressContainer>
         <StyledRoutineProgress>
-          <RoutineProgress missionObject={missionCompletionDummy} />
+          <RoutineProgress missionObject={todayMissionStatus} />
         </StyledRoutineProgress>
       </RoutineProgressContainer>
       <StyledButton onClick={() => history.push('/')}>종료하기</StyledButton>

--- a/src/pages/myRoutine/RoutineFinishPage.tsx
+++ b/src/pages/myRoutine/RoutineFinishPage.tsx
@@ -44,7 +44,11 @@ const RoutineFinishPage = (): JSX.Element => {
               isPassed: endTime === null ? true : false,
             };
           },
+        )
+        .sort(
+          (a: { orders: number }, b: { orders: number }) => a.orders - b.orders,
         );
+
       setTodayMissionStatus(missionStatus);
     } catch (e) {
       console.error('getFinishedRoutineDetail: ', e);

--- a/src/pages/myRoutine/RoutineProgressPage.tsx
+++ b/src/pages/myRoutine/RoutineProgressPage.tsx
@@ -347,7 +347,9 @@ const RoutineProgressPage = (): JSX.Element => {
     await sleep(450);
     setNextStep(false);
 
-    await startMission(missions[currentIndex + 1]);
+    if (currentIndex !== missions.length - 1) {
+      await startMission(missions[currentIndex + 1]);
+    }
   };
 
   const ProgressModalEmement = useMemo(() => {

--- a/src/pages/myRoutine/RoutineProgressPage.tsx
+++ b/src/pages/myRoutine/RoutineProgressPage.tsx
@@ -87,19 +87,23 @@ const RoutineProgressPage = (): JSX.Element => {
       );
       setProgress(missionInfo);
       setCurrentMissions(missionInfo[0]);
+      await startMission(missionInfo[0], routineStatusId);
     } catch (e) {
       console.error(e);
     }
   };
 
-  const startMission = async (currentMission: {
-    missionStatusId: number;
-    orders: number;
-  }) => {
+  const startMission = async (
+    currentMission: {
+      missionStatusId: number;
+      orders: number;
+    },
+    routine_StatusId?: number,
+  ) => {
     try {
       if (!routineId) return;
       const missionStatus = {
-        routineStatusId: routineStatusId,
+        routineStatusId: routine_StatusId ? routine_StatusId : routineStatusId,
         missionStatusId: currentMission['missionStatusId'],
         orders: currentMission['orders'],
         startTime: moment().toISOString(),


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

RoutineFinishPage - API 연동
- closed #159 

## 🧑‍💻 PR 세부 내용

# RoutineFinishPage
- 오늘 수행한 미션에 대해서 결과를 렌더링 합니다.
- API 연결했습니다.
- API 응답에 endTime 값이 비어있을 경우 미션을 `pass`한 것으로 판단하고 Pass 렌더링, 그 외에는 시간이 렌더링됩니다.

# MyRoutinePage
- `전체` 루틴 탭에서 완료, 미완료 루틴에 대한 체크 표시 로직 추가했습니다.
- 미완료 루틴 먼저 렌더링 후 완료한 루틴을 렌더링 하도록 수정했습니다.

# RoutineDetailPage
- 오늘 수행한 루틴이면 버튼 클릭했을 때 finish 페이지로 이동되게 했습니다.
- 오늘 수행 가능한 미션이 아니거나, 미션이 없을 때 validate 추가했습니다.

## 📸 스크린샷

https://user-images.githubusercontent.com/85148549/146681526-25006727-e4a0-4cbc-8085-19c5fb0effe3.mp4

