### PR TITLE
refactor: #169/RoutineProgressPage

### DIFF
--- a/src/pages/myRoutine/MyRoutinePage.tsx
+++ b/src/pages/myRoutine/MyRoutinePage.tsx
@@ -106,8 +106,17 @@ const MyRoutinePage = (): JSX.Element => {
     }
   };
 
-  const onClickUpdateRoutine = (routineId: number) => {
-    history.push(`/routine/${routineId}/update`);
+  const onClickUpdateRoutine = (routine: RoutineType) => {
+    const { routineId, posted } = routine;
+    if (posted) {
+      Swal.fire({
+        icon: 'error',
+        title: '이런, 루틴이 포스팅 되어있군요',
+        text: '포스팅 되어있는 루틴을 먼저 삭제해주세요',
+      });
+    } else {
+      history.push(`/routine/${routineId}/update`);
+    }
   };
 
   const onClickRoutine = (e: React.MouseEvent<HTMLElement>, id: any) => {
@@ -142,7 +151,7 @@ const MyRoutinePage = (): JSX.Element => {
                         deleteRoutine(routine);
                       }}
                       updateRoutine={() => {
-                        onClickUpdateRoutine(routine['routineId']);
+                        onClickUpdateRoutine(routine);
                       }}
                     />
                   ))}
@@ -158,7 +167,7 @@ const MyRoutinePage = (): JSX.Element => {
                         deleteRoutine(routine);
                       }}
                       updateRoutine={() => {
-                        onClickUpdateRoutine(routine['routineId']);
+                        onClickUpdateRoutine(routine);
                       }}
                     />
                   ))}
@@ -190,7 +199,7 @@ const MyRoutinePage = (): JSX.Element => {
                         deleteRoutine(routine);
                       }}
                       updateRoutine={() => {
-                        onClickUpdateRoutine(routine['routineId']);
+                        onClickUpdateRoutine(routine);
                       }}
                     />
                   ))}
@@ -222,7 +231,7 @@ const MyRoutinePage = (): JSX.Element => {
                         deleteRoutine(routine);
                       }}
                       updateRoutine={() => {
-                        onClickUpdateRoutine(routine['routineId']);
+                        onClickUpdateRoutine(routine);
                       }}
                     />
                   ))}

--- a/src/pages/myRoutine/MyRoutinePage.tsx
+++ b/src/pages/myRoutine/MyRoutinePage.tsx
@@ -34,9 +34,6 @@ const MyRoutinePage = (): JSX.Element => {
       const routines = await routineApi.getRoutines();
       const finishedRoutines = await routineApi.getFinishedRoutines();
       const notFinishedRoutines = await routineApi.getNotFinishedRoutines();
-      console.log(routines);
-      console.log(finishedRoutines);
-      console.log(notFinishedRoutines);
 
       const finishedRoutineIds = finishedRoutines.data.data.map(
         (routine: { routineId: number }) => routine.routineId,

--- a/src/pages/myRoutine/MyRoutinePage.tsx
+++ b/src/pages/myRoutine/MyRoutinePage.tsx
@@ -19,27 +19,35 @@ const MyRoutinePage = (): JSX.Element => {
     finish: [],
     notFinish: [],
   });
+  const [isLoading, setIsLoading] = useState(false);
   const history = useHistory();
   const token = sessionStorage.getItem('YAS_USER_TOKEN');
 
   const getMyRoutines = async () => {
-    const routines = await routineApi.getRoutines();
-    const finishedRoutines = await routineApi.getFinishedRoutines();
-    const notFinishedRoutines = await routineApi.getNotFinishedRoutines();
+    try {
+      if (!token) return;
+      setIsLoading(true);
+      const routines = await routineApi.getRoutines();
+      const finishedRoutines = await routineApi.getFinishedRoutines();
+      const notFinishedRoutines = await routineApi.getNotFinishedRoutines();
 
-    const finishedRoutineIds = finishedRoutines.data.data.map(
-      (routine: { routineId: number }) => routine.routineId,
-    );
-    const allRoutinesExceptFinished = routines.data.data.filter(
-      (routine: { routineId: number }) =>
-        !finishedRoutineIds.includes(routine.routineId),
-    );
+      const finishedRoutineIds = finishedRoutines.data.data.map(
+        (routine: { routineId: number }) => routine.routineId,
+      );
+      const allRoutinesExceptFinished = routines.data.data.filter(
+        (routine: { routineId: number }) =>
+          !finishedRoutineIds.includes(routine.routineId),
+      );
 
-    setRoutines({
-      all: allRoutinesExceptFinished,
-      finish: finishedRoutines.data.data,
-      notFinish: notFinishedRoutines.data.data,
-    });
+      setRoutines({
+        all: allRoutinesExceptFinished,
+        finish: finishedRoutines.data.data,
+        notFinish: notFinishedRoutines.data.data,
+      });
+      setIsLoading(false);
+    } catch (e) {
+      console.error('getMyRoutines: ', e);
+    }
   };
 
   useEffect(() => {
@@ -104,7 +112,7 @@ const MyRoutinePage = (): JSX.Element => {
     <Container navBar>
       <TabBar type="myRoutine">
         <TabBar.Item title="전체" index="0">
-          {token ? (
+          {isLoading ? null : token ? (
             routines.all.length !== 0 ? (
               <RoutineGridBox>
                 {routines.all &&
@@ -152,7 +160,7 @@ const MyRoutinePage = (): JSX.Element => {
           )}
         </TabBar.Item>
         <TabBar.Item title="오늘의 루틴" index="1">
-          {token ? (
+          {isLoading ? null : token ? (
             routines.notFinish.length !== 0 ? (
               <RoutineGridBox>
                 {routines.notFinish &&
@@ -184,7 +192,7 @@ const MyRoutinePage = (): JSX.Element => {
           )}
         </TabBar.Item>
         <TabBar.Item title="완료한 루틴" index="2">
-          {token ? (
+          {isLoading ? null : token ? (
             routines.finish.length !== 0 ? (
               <RoutineGridBox>
                 {routines.finish &&

--- a/src/pages/myRoutine/MyRoutinePage.tsx
+++ b/src/pages/myRoutine/MyRoutinePage.tsx
@@ -6,12 +6,16 @@ import {
   TabBar,
   LoginGuide,
 } from '@/components';
-import { RoutineType } from '@/Models';
+import { RoutineType as RT } from '@/Models';
 import { Colors, FontSize, Media } from '@/styles';
 import styled from '@emotion/styled';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import Swal from 'sweetalert2';
+
+interface RoutineType extends RT {
+  posted: boolean;
+}
 
 const MyRoutinePage = (): JSX.Element => {
   const [routines, setRoutines] = useState({
@@ -30,6 +34,9 @@ const MyRoutinePage = (): JSX.Element => {
       const routines = await routineApi.getRoutines();
       const finishedRoutines = await routineApi.getFinishedRoutines();
       const notFinishedRoutines = await routineApi.getNotFinishedRoutines();
+      console.log(routines);
+      console.log(finishedRoutines);
+      console.log(notFinishedRoutines);
 
       const finishedRoutineIds = finishedRoutines.data.data.map(
         (routine: { routineId: number }) => routine.routineId,
@@ -56,39 +63,47 @@ const MyRoutinePage = (): JSX.Element => {
   }, []);
 
   const deleteRoutine = async (routine: RoutineType) => {
-    const { routineId, name } = routine;
-    Swal.fire({
-      title: `${name}`,
-      text: '루틴을 삭제하겠습니까?',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: `${Colors.functionPositive}`,
-      cancelButtonColor: `${Colors.functionNegative}`,
-      confirmButtonText: '네',
-      cancelButtonText: '아니오',
-    }).then(async (result) => {
-      if (result.isConfirmed) {
-        try {
-          await routineApi.deleteRoutine(routineId);
-          Swal.fire({
-            position: 'center',
-            icon: 'success',
-            title: `${name}`,
-            text: '루틴이 삭제되었습니다.',
-            showConfirmButton: false,
-            timer: 1200,
-          });
+    const { routineId, name, posted } = routine;
+    if (posted) {
+      Swal.fire({
+        icon: 'error',
+        title: '이런, 루틴이 포스팅 되어있군요',
+        text: '포스팅 되어있는 루틴을 먼저 삭제해주세요',
+      });
+    } else {
+      Swal.fire({
+        title: `${name}`,
+        text: '루틴을 삭제하겠습니까?',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: `${Colors.functionPositive}`,
+        cancelButtonColor: `${Colors.functionNegative}`,
+        confirmButtonText: '네',
+        cancelButtonText: '아니오',
+      }).then(async (result) => {
+        if (result.isConfirmed) {
+          try {
+            await routineApi.deleteRoutine(routineId);
+            Swal.fire({
+              position: 'center',
+              icon: 'success',
+              title: `${name}`,
+              text: '루틴이 삭제되었습니다.',
+              showConfirmButton: false,
+              timer: 1200,
+            });
 
-          await getMyRoutines();
-        } catch (e) {
-          Swal.fire({
-            icon: 'error',
-            title: '이런',
-            text: '에러로 인해 루틴이 삭제되지 않았어요!',
-          });
+            await getMyRoutines();
+          } catch (e) {
+            Swal.fire({
+              icon: 'error',
+              title: '이런',
+              text: '에러로 인해 루틴이 삭제되지 않았어요!',
+            });
+          }
         }
-      }
-    });
+      });
+    }
   };
 
   const onClickUpdateRoutine = (routineId: number) => {

--- a/src/pages/myRoutine/RoutineFinishPage.tsx
+++ b/src/pages/myRoutine/RoutineFinishPage.tsx
@@ -4,7 +4,6 @@ import { Colors, FontSize, FontWeight, Media } from '@/styles';
 import styled from '@emotion/styled';
 import { useHistory, useParams } from 'react-router-dom';
 import { missionStatusApi, routineApi } from '@/apis';
-import moment from 'moment';
 
 interface RoutineInfoType {
   emoji: string;
@@ -25,8 +24,14 @@ const RoutineFinishPage = (): JSX.Element => {
       const result = await missionStatusApi.getMissionStatus(routineId);
       const missionStatus = result.data.data
         ?.filter(
-          (status: { missionStatusDetailResponse: { startTime: string } }) =>
-            moment(status.missionStatusDetailResponse.startTime).days() === 0,
+          (status: { missionStatusDetailResponse: { startTime: string } }) => {
+            const missionDate = new Date(
+              status.missionStatusDetailResponse.startTime + 'Z',
+            ).toLocaleDateString();
+            const today = new Date().toLocaleDateString();
+
+            return missionDate === today;
+          },
         )
         .map(
           (status: {

--- a/src/pages/myRoutine/RoutineProgressPage.tsx
+++ b/src/pages/myRoutine/RoutineProgressPage.tsx
@@ -5,6 +5,7 @@ import {
   IconButton,
   RoundedButton,
   RoutineInfo,
+  Spinner,
 } from '@/components';
 import styled from '@emotion/styled';
 import { Colors, FontSize, FontWeight, Media } from '@/styles';
@@ -32,6 +33,7 @@ const RoutineProgressPage = (): JSX.Element => {
   const [missions, setMissions] = useState<any>([]);
   const [currentMissions, setCurrentMissions] = useState<any>({});
   const [routineStatusId, setRoutineStatusId] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
   // 예외처리
   const { id } = useParams<Record<string, string>>();
   const routineId = id && parseInt(id);
@@ -39,6 +41,7 @@ const RoutineProgressPage = (): JSX.Element => {
   const createRoutineProgress = async () => {
     try {
       if (!routineId) return;
+      setIsLoading(true);
       const finishedRoutines = await routineApi.getFinishedRoutines();
       const finishedRoutineIds = finishedRoutines.data.data.map(
         (routine: { routineId: number }) => routine.routineId,
@@ -111,6 +114,7 @@ const RoutineProgressPage = (): JSX.Element => {
       setProgress(missionInfo);
       setCurrentMissions(missionInfo[0]);
       await startMission(missionInfo[0], routineStatusId);
+      setIsLoading(false);
     } catch (e) {
       console.error(e);
     }
@@ -421,6 +425,7 @@ const RoutineProgressPage = (): JSX.Element => {
         <RoundedButton.Play isPlay={isPlay} onClick={toggle} />
         <IconButton.Check onClick={handleCheckClick} />
       </ButtonContainer>
+      {isLoading && <Spinner />}
     </Container>
   );
 };


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

RoutineProgressPage - mission-status API 관련 리팩토링
- closed #169 

## 🧑‍💻 PR 세부 내용

# RoutineProgressPage
- 미션 `Pass`, 미션 `수행`에 따른 API 호출 특이점 없었습니다.
- 이미 `완료한 루틴`에 대해 url주소 또는 버그 등으로 progress 페이지에 진입했을 때 API 호출 없이 `RoutineFinishPage로 이동`하도록 로직 추가했습니다.
- 루틴 완료 후 페이지 이동 시 `history.push() → history.replace()`로 수정했습니다.(완료 페이지에서 뒤로가기 눌렀을 때 RoutineDetailPage로 이동)

# RoutineFinishPage
- 오늘 수행한 미션만 렌더링 되도록 수정했습니다.(루틴 수행은 1일 2회이상 불가능)
- 미완료한 루틴으로 해당 페이지에 진입하면 알림 후 `RoutineDetailPage`로 이동합니다.

# MyRoutinePage
- 로그인 상태일 때만 루틴 조회 API 호출되도록 했습니다.
- API호출로 로딩중일 때 안내 문구(`루틴이 없습니다` 등)가 보이지 않도록 수정했습니다.
- `<Spinner />` 컴포넌트 사용해봤는데, API 호출 시간이 짧아서 깜빡이는 것처럼 보여 적용하진 않았습니다.
- `posted` 데이터가 추가되어 포스팅된 루틴은 삭제, 수정이 불가능하도록 Swal 적용했습니다.

# RoutineDetaiPage
- `posted` 데이터가 추가되어 포스팅된 루틴은 삭제, 수정이 불가능하도록 Swal 적용했습니다.

## RoutineDetailPage 의논
- 포스팅된 루틴일 때 `+`버튼, 미션에 있는 `DeleteBox`를 안보이게 하고, 연필 모양 수정 버튼만 남겨서 연필 버튼 누르면 알림 뜨게 했는데, 이렇게 진행할까요~??

<img width="700" src="https://user-images.githubusercontent.com/85148549/146743865-89add1e3-2e93-4e77-a5ae-67b0ce40c387.png" />




## 📸 스크린샷

https://user-images.githubusercontent.com/85148549/146743191-55e94747-0a13-4a0c-9924-4d067eb65639.mp4

