### PR TITLE
feat: #181/UserToolBox

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -51,6 +51,8 @@ export { SpreadToggle } from './molecules/SpreadToggle';
 export type { SpreadToggleProps } from './molecules/SpreadToggle';
 export { LoginGuide } from './molecules/LoginGuide';
 export type { LoginGuideProps } from './molecules/LoginGuide';
+export { UserToolBox } from './molecules/ToolBox';
+export type { UserToolBoxProps } from './molecules/ToolBox';
 
 //! Organism Component
 export { RoutineAddButton } from './organisms/RoutineAddButton';

--- a/src/components/molecules/ToolBox/UserToolBox.tsx
+++ b/src/components/molecules/ToolBox/UserToolBox.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { IconButton } from '@mui/material';
+import AccountBoxRoundedIcon from '@mui/icons-material/AccountBoxRounded';
+import ExitToAppRoundedIcon from '@mui/icons-material/ExitToAppRounded';
+import { Colors, FontSize, Shadow } from '@/styles';
+import { useClickAway } from '@/hooks';
+// import Container from './Container';
+import { Icon } from '@/components/';
+
+export interface UserToolBoxProps extends React.ComponentProps<'div'> {
+  onClickUserButton?: (e: React.MouseEvent) => void;
+  onClickSignOutButton?: (e: React.MouseEvent) => void;
+  visible?: boolean;
+  onClose?: () => void;
+}
+
+const UserToolBox = ({
+  visible = true,
+  onClose,
+  onClickUserButton,
+  onClickSignOutButton,
+  style,
+  ...props
+}: UserToolBoxProps): JSX.Element => {
+  const ref = useClickAway(() => {
+    onClose && onClose();
+  });
+
+  const handleClickUserButton = (e: React.MouseEvent<HTMLButtonElement>) => {
+    console.log('handleClickUserButton');
+    onClickUserButton && onClickUserButton(e);
+  };
+
+  const handleClickSignOutButton = (e: React.MouseEvent<HTMLButtonElement>) => {
+    console.log('handleClickSignOutButton');
+    onClickSignOutButton && onClickSignOutButton(e);
+  };
+
+  return (
+    <Container
+      ref={ref}
+      style={{ display: visible ? 'inline-flex' : 'none', ...style }}
+      {...props}
+    >
+      <StyledButton onClick={handleClickUserButton}>
+        <AccountBoxRoundedIcon color="action" />
+        <Text>마이페이지</Text>
+      </StyledButton>
+      <StyledButton onClick={handleClickSignOutButton}>
+        <ExitToAppRoundedIcon color="action" />
+        <Text>로그아웃</Text>
+      </StyledButton>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  position: absolute;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  background-color: rgba(255, 255, 255, 0.5);
+  box-shadow: ${Shadow.menu};
+  border-radius: 0.5rem;
+  z-index: 1;
+`;
+
+const Text = styled.p`
+  color: ${Colors.textPrimary};
+  font-size: ${FontSize.small};
+`;
+
+const StyledButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+
+  & svg {
+    margin-right: 0.5rem;
+  }
+
+  &:hover {
+    & path {
+      fill: ${Colors.point};
+    }
+
+    & p {
+      color: ${Colors.point};
+    }
+  }
+`;
+
+export default UserToolBox;

--- a/src/components/molecules/ToolBox/UserToolBox.tsx
+++ b/src/components/molecules/ToolBox/UserToolBox.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { IconButton } from '@mui/material';
 import AccountBoxRoundedIcon from '@mui/icons-material/AccountBoxRounded';
 import ExitToAppRoundedIcon from '@mui/icons-material/ExitToAppRounded';
 import { Colors, FontSize, Shadow } from '@/styles';
 import { useClickAway } from '@/hooks';
-// import Container from './Container';
-import { Icon } from '@/components/';
 
 export interface UserToolBoxProps extends React.ComponentProps<'div'> {
   onClickUserButton?: (e: React.MouseEvent) => void;

--- a/src/components/molecules/ToolBox/UserToolBox.tsx
+++ b/src/components/molecules/ToolBox/UserToolBox.tsx
@@ -25,12 +25,10 @@ const UserToolBox = ({
   });
 
   const handleClickUserButton = (e: React.MouseEvent<HTMLButtonElement>) => {
-    console.log('handleClickUserButton');
     onClickUserButton && onClickUserButton(e);
   };
 
   const handleClickSignOutButton = (e: React.MouseEvent<HTMLButtonElement>) => {
-    console.log('handleClickSignOutButton');
     onClickSignOutButton && onClickSignOutButton(e);
   };
 

--- a/src/components/molecules/ToolBox/index.ts
+++ b/src/components/molecules/ToolBox/index.ts
@@ -1,4 +1,6 @@
 export { default as EditBox } from './EditBox';
 export { default as DeleteBox } from './DeleteBox';
+export { default as UserToolBox } from './UserToolBox';
 export type { DeleteBoxProps } from './DeleteBox';
 export type { EditBoxProps } from './EditBox';
+export type { UserToolBoxProps } from './UserToolBox';

--- a/src/components/templates/Header/Header.tsx
+++ b/src/components/templates/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Swal from 'sweetalert2';
 import { logoWide } from '@/images';
 import styled from '@emotion/styled';
@@ -9,10 +9,12 @@ import { RootState, user as userStore } from '@/store';
 import { Link, useRouteMatch, useHistory } from 'react-router-dom';
 import HelpOutlineRoundedIcon from '@mui/icons-material/HelpOutlineRounded';
 import BackButton from './BackButton';
+import { UserToolBox } from '@/components';
 
 export type HeaderProps = React.ComponentProps<'header'>;
 
 const Header = ({ ...props }: HeaderProps): JSX.Element => {
+  const [userToolBoxVisible, setUserToolBoxVisible] = useState<boolean>(false);
   const { data: user } = useSelector((state: RootState) => state.user);
   const [match, history] = [useRouteMatch(), useHistory()];
   const params = parseParams(match.url);
@@ -46,6 +48,14 @@ const Header = ({ ...props }: HeaderProps): JSX.Element => {
     history.goBack();
   };
 
+  const handleCloseUserToolBox = () => {
+    setUserToolBoxVisible(false);
+  };
+
+  const handleClickUserButton = () => {
+    history.push('/mypage');
+  };
+
   return (
     <Container {...props}>
       <ContentContainer>
@@ -74,18 +84,21 @@ const Header = ({ ...props }: HeaderProps): JSX.Element => {
                 src={user?.profileImage}
                 on={params[0] === 'mypage' ? 1 : 0}
                 onClick={() => {
-                  history.push('/mypage');
+                  setUserToolBoxVisible(true);
                 }}
               />
-              <Button onClick={handleClickLogOutButton}>
-                <Text>로그아웃</Text>
-              </Button>
             </>
           ) : (
             <Link to="/mypage/signin">
               <Text>로그인</Text>
             </Link>
           )}
+          <StyledUserToolBox
+            visible={userToolBoxVisible}
+            onClose={handleCloseUserToolBox}
+            onClickUserButton={handleClickUserButton}
+            onClickSignOutButton={handleClickLogOutButton}
+          />
         </RightAside>
       </ContentContainer>
     </Container>
@@ -210,6 +223,24 @@ const Button = styled.button`
   border: none;
   background-color: transparent;
   cursor: pointer;
+`;
+
+const StyledUserToolBox = styled(UserToolBox)`
+  position: absolute;
+  z-index: 1;
+
+  @media ${Media.sm} {
+    top: 3rem;
+    right: 1rem;
+  }
+  @media ${Media.md} {
+    top: 4rem;
+    right: 2rem;
+  }
+  @media ${Media.lg} {
+    top: 4rem;
+    right: 2rem;
+  }
 `;
 
 export default Header;

--- a/src/components/templates/Header/Header.tsx
+++ b/src/components/templates/Header/Header.tsx
@@ -219,12 +219,6 @@ const Text = styled.p`
   }
 `;
 
-const Button = styled.button`
-  border: none;
-  background-color: transparent;
-  cursor: pointer;
-`;
-
 const StyledUserToolBox = styled(UserToolBox)`
   position: absolute;
   z-index: 1;

--- a/src/components/templates/Header/Header.tsx
+++ b/src/components/templates/Header/Header.tsx
@@ -72,7 +72,7 @@ const Header = ({ ...props }: HeaderProps): JSX.Element => {
                   history.push('/onboarding');
                 }}
               >
-                <HelpIcon />
+                <HelpIcon on={params[0] === 'onboarding' ? 1 : 0} />
               </IconButton>
             </>
           )}
@@ -186,8 +186,8 @@ const RightAside = styled.div`
   gap: 1rem;
 `;
 
-const HelpIcon = styled(HelpOutlineRoundedIcon)`
-  color: ${Colors.pointLight};
+const HelpIcon = styled(HelpOutlineRoundedIcon)<{ on: number }>`
+  color: ${({ on }) => (on ? Colors.point : Colors.pointLight)};
   width: 32px;
   height: 32px;
 `;

--- a/src/stories/components/molecules/UserToolBox.stories.tsx
+++ b/src/stories/components/molecules/UserToolBox.stories.tsx
@@ -1,0 +1,10 @@
+import { UserToolBox, UserToolBoxProps } from '@/components';
+
+export default {
+  title: 'Components/Molecules/UserToolBox',
+  component: UserToolBox,
+};
+
+export const Default = ({ ...args }: UserToolBoxProps): JSX.Element => {
+  return <UserToolBox />;
+};


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

UserToolBox 컴포넌트 구현
- close #181 

## 🧑‍💻 PR 세부 내용

- UserToolBox 컴포넌트 구현 후 헤더에 반영하였습니다.
- onBoardingButton 클릭후 활성화 시 색상이 진해지도록 변경하였습니다.

## 📸 스크린샷

https://user-images.githubusercontent.com/41064875/149812529-12be0f29-b4a9-4bcc-add7-fed17c00f6fc.mov



