### PR TITLE
refactor: #183/MissionCreatePage

### DIFF
--- a/src/Models/dummy.ts
+++ b/src/Models/dummy.ts
@@ -17,7 +17,7 @@ export const routineDummy: RoutineType = {
   durationGoalTime: 1000,
   weeks: ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
   routineCategory: ['HEALTH', 'EXERCISE'],
-  missionDetailResponse: [],
+  missionDetailResponses: [],
 };
 
 export const missionDummy: MissionType = {

--- a/src/Models/types.ts
+++ b/src/Models/types.ts
@@ -15,7 +15,7 @@ export interface RoutineType {
   durationGoalTime: number;
   weeks: string[];
   routineCategory: string[];
-  missionDetailResponse: MissionType[];
+  missionDetailResponses: MissionType[];
   // routineCompletions: RoutineCompletionType[];
 }
 

--- a/src/pages/myRoutine/MissionCreatePage.tsx
+++ b/src/pages/myRoutine/MissionCreatePage.tsx
@@ -18,10 +18,13 @@ import { Colors, FontSize, Media } from '@/styles';
 import styled from '@emotion/styled';
 import Swal from 'sweetalert2';
 import { useHistory, useParams } from 'react-router-dom';
-import { routineApi, missionApi } from '@/apis';
+import { missionApi } from '@/apis';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchRoutine, RootState } from '@/store';
 
 const MissionCreatePage = (): JSX.Element => {
   const history = useHistory();
+  const dispatch = useDispatch();
   const { id } = useParams<Record<string, string>>();
   const [mission, setMission] = useState<Omit<MissionType, 'missionId'>>({
     name: '',
@@ -31,18 +34,22 @@ const MissionCreatePage = (): JSX.Element => {
     orders: 0,
   });
 
-  // TODO : 현재 루틴 컬러 및 미션 순서 스토어에서 가져오는 걸로 변경
+  const { data: routine } = useSelector((state: RootState) => state.routine);
+
   const getColorAndOrders = useCallback(async () => {
-    // 예외처리
-    if (!id) return;
-    const response = await routineApi.getRoutine(parseInt(id));
-    const { color, missionDetailResponses } = response.data.data;
+    if (!routine) return;
+    const { color, missionDetailResponses } = routine;
     setMission((mission) => ({
       ...mission,
       color,
       orders: missionDetailResponses.length,
     }));
-  }, [id]);
+  }, [routine]);
+
+  useEffect(() => {
+    if (!id) return;
+    dispatch(fetchRoutine(parseInt(id)));
+  }, [id, dispatch]);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/pages/myRoutine/RoutineCreatePage.tsx
+++ b/src/pages/myRoutine/RoutineCreatePage.tsx
@@ -41,7 +41,7 @@ const RoutineCreatePage = (): JSX.Element => {
     : '';
 
   const [routine, setRoutine] = useState<
-    Omit<RoutineType, 'routineId' | 'missionDetailResponse'> & {
+    Omit<RoutineType, 'routineId' | 'missionDetailResponses'> & {
       missionCreateRequest: MissionType[];
     }
   >(

--- a/src/pages/myRoutine/RoutineUpdatePage.tsx
+++ b/src/pages/myRoutine/RoutineUpdatePage.tsx
@@ -11,7 +11,7 @@ const RoutineUpdatePage = (): JSX.Element => {
   const history = useHistory();
   const { id } = useParams<Record<string, string>>();
   const [selectedRoutine, setSelectedRoutine] = useState<
-    Omit<RoutineType, 'missionDetailResponse'>
+    Omit<RoutineType, 'missionDetailResponses'>
   >({
     routineId: 0,
     emoji: '',

--- a/src/stories/components/molecules/Routine.stories.tsx
+++ b/src/stories/components/molecules/Routine.stories.tsx
@@ -55,7 +55,7 @@ export const Default = (): JSX.Element => {
           durationGoalTime: 0,
           startGoalTime: `${new Date().toISOString()}`,
           routineCategory: [],
-          missionDetailResponse: [],
+          missionDetailResponses: [],
           weeks: [],
         }}
         type="create"


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

미션 생성 페이지에서 루틴 정보 가져올 때 기존 API 요청 방식에서 Store에서 가져오는 방식으로 리팩토링 

## 🧑‍💻 PR 세부 내용

- 루틴 정보 기존 API 요청 방식에서 Store에서 가져오는 방식으로 리팩토링 
- types의 루틴 타입 내 missionDetailResponse -> missionDetailResponses  변수명 변경으로 인해 몇몇 파일 수정 
