### PR TITLE
refactor: #190/RoutinePostDetailPage

### DIFF
--- a/src/Models/types.ts
+++ b/src/Models/types.ts
@@ -59,7 +59,7 @@ export interface RoutinePostType {
   postId: number;
   title: string;
   user: Omit<UserType, 'email'>;
-  conntent: string;
+  content: string;
   routine: {
     routineId: number;
     name: string;

--- a/src/Models/types.ts
+++ b/src/Models/types.ts
@@ -59,6 +59,7 @@ export interface RoutinePostType {
   postId: number;
   title: string;
   user: Omit<UserType, 'email'>;
+  conntent: string;
   routine: {
     routineId: number;
     name: string;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -54,6 +54,8 @@ export { LoginGuide } from './molecules/LoginGuide';
 export type { LoginGuideProps } from './molecules/LoginGuide';
 export { UserToolBox } from './molecules/ToolBox';
 export type { UserToolBoxProps } from './molecules/ToolBox';
+export { RoutinePostContent } from './molecules/RoutinePostContent';
+export type { RoutinePostContentProps } from './molecules/RoutinePostContent';
 
 //! Organism Component
 export { RoutineAddButton } from './organisms/RoutineAddButton';

--- a/src/components/molecules/RoutinePostContent/RoutinePostContent.tsx
+++ b/src/components/molecules/RoutinePostContent/RoutinePostContent.tsx
@@ -46,7 +46,6 @@ const RoutinePostContent = ({
 };
 
 const Container = styled.div`
-  /* position: relative; */
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/src/components/molecules/RoutinePostContent/RoutinePostContent.tsx
+++ b/src/components/molecules/RoutinePostContent/RoutinePostContent.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Colors, Media, FontSize } from '@/styles';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { SpreadToggle } from '../SpreadToggle';
 
 export interface RoutinePostContentProps extends React.ComponentProps<'div'> {
   content?: string;
@@ -10,23 +11,82 @@ const RoutinePostContent = ({
   content = '',
   ...props
 }: RoutinePostContentProps): JSX.Element => {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const [spreadable, setSpreadable] = useState<boolean>(false);
+  const [opened, setOpened] = useState<boolean>(false);
+  const scrollHeight = ref.current?.scrollHeight;
+
+  useEffect(() => {
+    if (!scrollHeight) return;
+    setSpreadable(scrollHeight > 29);
+  }, [setSpreadable, ref, scrollHeight]);
+
+  const handleClickSpreadToggle = () => {
+    setOpened((opened) => !opened);
+  };
+
   return (
     <Container {...props}>
-      <Text>{content}</Text>
+      <TextArea
+        opened={opened}
+        height={scrollHeight}
+        ref={ref}
+        readOnly
+        value={content}
+      >
+        {content}
+      </TextArea>
+      {spreadable && (
+        <SpreadToggleWrapper>
+          <SpreadToggle onClick={handleClickSpreadToggle} />
+        </SpreadToggleWrapper>
+      )}
     </Container>
   );
 };
 
 const Container = styled.div`
+  /* position: relative; */
   display: flex;
+  flex-direction: column;
   width: 100%;
-  height: 40px;
   margin-bottom: 1rem;
-  padding: 1rem;
+  padding: 1rem 1.5rem 0.5rem 1.5rem;
   border-radius: 0.5rem;
   background-color: ${Colors.backgroundButton}; ;
 `;
 
-const Text = styled.p``;
+const TextArea = styled.textarea<
+  React.ComponentProps<'textarea'> & {
+    opened: boolean;
+    height: number | undefined;
+  }
+>`
+  width: 100%;
+  height: ${({ opened, height }) => (opened ? `${height}px` : '1.8rem')};
+  overflow-y: hidden;
+  text-overflow: ellipsis;
+  background-color: transparent;
+  resize: none;
+  border: none;
+  outline: none;
+  color: ${Colors.textPrimary};
+
+  @media ${Media.sm} {
+    font-size: ${FontSize.small};
+  }
+  @media ${Media.md} {
+    font-size: ${FontSize.base};
+  }
+  @media ${Media.lg} {
+    font-size: ${FontSize.base};
+  }
+`;
+
+const SpreadToggleWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 export default RoutinePostContent;

--- a/src/components/molecules/RoutinePostContent/RoutinePostContent.tsx
+++ b/src/components/molecules/RoutinePostContent/RoutinePostContent.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import { Colors, Media, FontSize } from '@/styles';
+import React from 'react';
+
+export interface RoutinePostContentProps extends React.ComponentProps<'div'> {
+  content?: string;
+}
+
+const RoutinePostContent = ({
+  content = '',
+  ...props
+}: RoutinePostContentProps): JSX.Element => {
+  return (
+    <Container {...props}>
+      <Text>{content}</Text>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  width: 100%;
+  height: 40px;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background-color: ${Colors.backgroundButton}; ;
+`;
+
+const Text = styled.p``;
+
+export default RoutinePostContent;

--- a/src/components/molecules/RoutinePostContent/index.tsx
+++ b/src/components/molecules/RoutinePostContent/index.tsx
@@ -1,0 +1,2 @@
+export { default as RoutinePostContent } from './RoutinePostContent';
+export type { RoutinePostContentProps } from './RoutinePostContent';

--- a/src/components/molecules/SpreadToggle/SpreadToggle.tsx
+++ b/src/components/molecules/SpreadToggle/SpreadToggle.tsx
@@ -59,7 +59,7 @@ const SpreadButton = styled.button`
     }
   }
 
-  &: active {
+  :active {
     color: ${Colors.pointLight};
   }
 `;

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -9,6 +9,7 @@ import {
   Spinner,
   IconButton,
   SpreadToggle,
+  RoutinePostContent,
 } from '@/components';
 import Swal from 'sweetalert2';
 import styled from '@emotion/styled';
@@ -171,9 +172,7 @@ const RoutinePostDetailPage = (): JSX.Element => {
           count={postData && postData.likes.length}
         />
       </RoutineInfoHeader>
-      <RoutinePostContent>
-        <Text>{postData && postData.content}</Text>
-      </RoutinePostContent>
+      <RoutinePostContent content={postData && postData.content} />
       <RoutineInfo
         createdAt={postData && postData.createdAt}
         routineObject={{
@@ -351,9 +350,5 @@ const CommentContainer = styled.div`
   margin: 1rem 0;
   width: 100%;
 `;
-
-const RoutinePostContent = styled.div``;
-
-const Text = styled.p``;
 
 export default RoutinePostDetailPage;

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -171,6 +171,9 @@ const RoutinePostDetailPage = (): JSX.Element => {
           count={postData && postData.likes.length}
         />
       </RoutineInfoHeader>
+      <RoutinePostContent>
+        <Text>{postData && postData.content}</Text>
+      </RoutinePostContent>
       <RoutineInfo
         createdAt={postData && postData.createdAt}
         routineObject={{
@@ -348,5 +351,9 @@ const CommentContainer = styled.div`
   margin: 1rem 0;
   width: 100%;
 `;
+
+const RoutinePostContent = styled.div``;
+
+const Text = styled.p``;
 
 export default RoutinePostDetailPage;

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -304,7 +304,7 @@ const BringRoutineButton = styled.button`
     }
   }
 
-  :active  {
+  :active {
     background-color: ${Colors.backgroundButton};
   }
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

RoutinePostDetailPage 리팩토링

- close #190 

## 🧑‍💻 PR 세부 내용

- RoutinePostDetailPage에서 컨텐트 내용이 보이도록 RoutinePostContent 컴포넌트를 추가했습니다.
- 한 줄일 때는 펼치기가 없고 여러줄일 때는 펼치기가 있습니다.
- 여러줄일 때 기본적으로 한 줄만 보여지도록 하였습니다.


## 📸 스크린샷


https://user-images.githubusercontent.com/41064875/150499199-6658acbf-775b-47e9-bd8c-10f9cc497df5.mov


