### PR TITLE
feat: #195/Page Component - PasswordEditPage

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -17,6 +17,10 @@ interface UserApiType {
   getUser: () => Promise<AxiosResponse>;
   updateUser: (formData: FormData) => Promise<AxiosResponse>;
   validateEmail: (email: string) => Promise<AxiosResponse>;
+  updatePassword: (
+    currentPassword: string,
+    newPassword: string,
+  ) => Promise<AxiosResponse>;
 }
 
 const userApi: UserApiType = {
@@ -29,6 +33,13 @@ const userApi: UserApiType = {
   },
   validateEmail: (email) => {
     return request.get('/users/email', { params: { value: email } });
+  },
+  updatePassword: (currentPassword: string, newPassword: string) => {
+    return authRequest.put('/users/password', {
+      newPassword: newPassword,
+      newPasswordCheck: newPassword,
+      nowPassword: currentPassword,
+    });
   },
 };
 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -14,6 +14,7 @@ export { SignInPage } from './user';
 export { SignUpPage } from './user';
 export { UserEditPage } from './user';
 export { UserPage } from './user';
+export { PasswordEditPage } from './user';
 
 export { AnalysisPage } from './analysis';
 

--- a/src/pages/user/PasswordEditPage.tsx
+++ b/src/pages/user/PasswordEditPage.tsx
@@ -69,10 +69,11 @@ const PasswordEditPage = (): JSX.Element => {
         }).then(() => {
           history.replace('/');
         });
-      } catch (error) {
+      } catch (error: any) {
+        const message = error.data.message || '비밀번호를 확인해주세요.';
         Swal.fire({
           icon: 'error',
-          text: '비밀번호를 확인해주세요.',
+          text: message,
           confirmButtonColor: Colors.point,
         });
       }

--- a/src/pages/user/PasswordEditPage.tsx
+++ b/src/pages/user/PasswordEditPage.tsx
@@ -81,7 +81,7 @@ const PasswordEditPage = (): JSX.Element => {
 
   return (
     <StyledContainer navBar>
-      <HeadText>프로필 수정</HeadText>
+      <HeadText>비밀번호 수정</HeadText>
       <Form onSubmit={handleSubmit}>
         <Label htmlFor="currentPassword">현재 비밀번호</Label>
         <Input

--- a/src/pages/user/PasswordEditPage.tsx
+++ b/src/pages/user/PasswordEditPage.tsx
@@ -1,0 +1,164 @@
+import * as Yup from 'yup';
+import Swal from 'sweetalert2';
+import styled from '@emotion/styled';
+import { useFormik } from 'formik';
+import { Colors, FontSize, FontWeight } from '@/styles';
+import { Container, Input, Button, Spinner } from '@/components';
+import { useHistory } from 'react-router-dom';
+import { userApi } from '@/apis';
+import { useDispatch } from 'react-redux';
+import { user as userStore } from '@/store';
+
+const validationSchema = Yup.object().shape({
+  currentPassword: Yup.string()
+    .min(8, '비밀번호는 최소 8글자 이상이어야 합니다.')
+    .max(20, '비밀번호는 최대 20글자 이하까지만 가능합니다.')
+    .matches(
+      /^(?=.*[a-zA-Z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,20}$/,
+      '영문자, 숫자, 특수문자를 포함해야 합니다.',
+    )
+    .required('비밀번호를 입력해주세요.'),
+  newPassword: Yup.string()
+    .min(8, '비밀번호는 최소 8글자 이상이어야 합니다.')
+    .max(20, '비밀번호는 최대 20글자 이하까지만 가능합니다.')
+    .matches(
+      /^(?=.*[a-zA-Z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,20}$/,
+      '영문자, 숫자, 특수문자를 포함해야 합니다.',
+    )
+    .required('비밀번호를 입력해주세요.'),
+  checkedNewPassword: Yup.string()
+    .oneOf([Yup.ref('newPassword'), null], '비밀번호가 일치하지 않습니다.')
+    .required('확인 비밀번호를 입력해주세요.'),
+});
+
+const PasswordEditPage = (): JSX.Element => {
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const initialValues = {
+    currentPassword: '',
+    newPassword: '',
+    checkedNewPassword: '',
+  };
+
+  const {
+    errors,
+    handleBlur,
+    handleChange,
+    handleSubmit,
+    isSubmitting,
+    touched,
+    values,
+  } = useFormik({
+    initialValues,
+    validationSchema,
+    onSubmit: async (values, formikHelper) => {
+      try {
+        await userApi.updatePassword(
+          values.currentPassword,
+          values.newPassword,
+        );
+        sessionStorage.removeItem('YAS_USER_TOKEN');
+        dispatch(userStore.actions.deleteUser());
+        formikHelper.setStatus({ success: true });
+        formikHelper.setSubmitting(false);
+        Swal.fire({
+          icon: 'success',
+          title: '비밀번호가 수정되었습니다.',
+          text: '다시 로그인을 진행해주세요.',
+        }).then(() => {
+          history.replace('/');
+        });
+      } catch (error) {
+        Swal.fire({
+          icon: 'error',
+          text: `${error}`,
+          confirmButtonColor: Colors.point,
+        });
+      }
+    },
+  });
+
+  return (
+    <StyledContainer navBar>
+      <HeadText>프로필 수정</HeadText>
+      <Form onSubmit={handleSubmit}>
+        <Label htmlFor="currentPassword">현재 비밀번호</Label>
+        <Input
+          id="currentPassword"
+          name="currentPassword"
+          type="password"
+          placeholder="현재 비밀번호"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          value={values.currentPassword}
+        />
+        <GuideText>
+          {touched.currentPassword && errors.currentPassword}&nbsp;
+        </GuideText>
+        <Label htmlFor="newPassword">새로운 비밀번호</Label>
+        <Input
+          id="newPassword"
+          name="newPassword"
+          type="password"
+          placeholder="새로운 비밀번호"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          value={values.newPassword}
+        />
+        <GuideText>{touched.newPassword && errors.newPassword}&nbsp;</GuideText>
+        <Label htmlFor="checkedNewPassword">새로운 비밀번호 확인</Label>
+        <Input
+          id="checkedNewPassword"
+          name="checkedNewPassword"
+          type="password"
+          placeholder="새로운 비밀번호 확인"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          value={values.checkedNewPassword ? values.checkedNewPassword : ''}
+        />
+        <GuideText>
+          {touched.checkedNewPassword && errors.checkedNewPassword}&nbsp;
+        </GuideText>
+        <Button type="submit">수정완료</Button>
+      </Form>
+      {isSubmitting && <Spinner />}
+    </StyledContainer>
+  );
+};
+
+const StyledContainer = styled(Container)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+`;
+
+const HeadText = styled.h1`
+  margin-bottom: 80px;
+  font-size: 24px;
+  font-weight: ${FontWeight.bold};
+  color: ${Colors.textPrimary};
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 2rem;
+`;
+
+const Label = styled.label`
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-size: ${FontSize.base};
+  color: ${Colors.textSecondary};
+`;
+
+const GuideText = styled.p`
+  margin: 1rem 0;
+  color: ${Colors.functionNegative};
+`;
+
+export default PasswordEditPage;

--- a/src/pages/user/PasswordEditPage.tsx
+++ b/src/pages/user/PasswordEditPage.tsx
@@ -72,7 +72,7 @@ const PasswordEditPage = (): JSX.Element => {
       } catch (error) {
         Swal.fire({
           icon: 'error',
-          text: `${error}`,
+          text: '비밀번호를 확인해주세요.',
           confirmButtonColor: Colors.point,
         });
       }

--- a/src/pages/user/UserEditPage.tsx
+++ b/src/pages/user/UserEditPage.tsx
@@ -141,10 +141,10 @@ const UserEditPage = (): JSX.Element => {
         colorType="white"
         type="button"
         onClick={() => {
-          history.goBack();
+          history.push('/mypage/edit/password');
         }}
       >
-        취소하기
+        비밀번호 수정하기
       </Button>
       {isSubmitting && <Spinner />}
     </StyledContainer>

--- a/src/pages/user/index.ts
+++ b/src/pages/user/index.ts
@@ -2,3 +2,4 @@ export { default as SignInPage } from './SignInPage';
 export { default as SignUpPage } from './SignUpPage';
 export { default as UserEditPage } from './UserEditPage';
 export { default as UserPage } from './UserPage';
+export { default as PasswordEditPage } from './PasswordEditPage';

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -15,6 +15,7 @@ import {
   SignInPage,
   SignUpPage,
   UserEditPage,
+  PasswordEditPage,
   UserPage,
   SocialSignInPage,
   AnalysisPage,
@@ -75,6 +76,11 @@ const Router = (): JSX.Element => {
 
       <PrivateRoute path="/mypage" exact component={UserPage} />
       <PrivateRoute path="/mypage/edit" exact component={UserEditPage} />
+      <PrivateRoute
+        path="/mypage/edit/password"
+        exact
+        component={PasswordEditPage}
+      />
       <PublicRoute
         restricted
         path="/mypage/signin"


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

PasswordEditPage 구현

- close #195 

## 🧑‍💻 PR 세부 내용

- 유저의 비밀번호를 수정할 수 있는 PasswordEditPage를 추가햇습니다.
- 라우터는 `/mypage/edit/password` 입니다!
- 기존에 유저 수정 페이지에서 취소하기 버튼을 비밀번호 수정하기 버튼으로 변경하였습니다.
- [x] 서버에서 잘못된 비밀번호를 받을경우 에러 메세지를 던져주는것을 요청드렸습니다. 서버에서 변경이 되면 에러메세지 출력되도록 변경하겠습니다. 현재는 비밀번호를 틀릴 경우 `비밀번호를 확인해주세요.`라는 메세지를 고정시켰습니다. 
  - 에러일경우 api에서 반환하는 에러메세지가 alert로 출력되도록 수정하였습니다!


## 📸 스크린샷



https://user-images.githubusercontent.com/41064875/150569312-eebc464a-d1f1-42f5-ac4b-7b625ebb9cd5.mov


