### PR TITLE
feat: #202/Page Component - Analysis Page

### DIFF
--- a/src/Models/index.ts
+++ b/src/Models/index.ts
@@ -9,6 +9,7 @@ export type { RoutinePostWindowType } from './types';
 export type { CommentType } from './types';
 export type { PostLikeType } from './types';
 export type { CommentLikeType } from './types';
+export type { RoutineStatusType } from './types';
 
 // !Dummy
 export { userDummy } from './dummy';

--- a/src/Models/types.ts
+++ b/src/Models/types.ts
@@ -124,3 +124,14 @@ export interface CommentLikeType {
   commentId: number;
   userId: number;
 }
+
+export interface RoutineStatusType {
+  routineStatusId: number;
+  dateTime: string;
+  routineListResponse: {
+    routineId: number;
+    name: string;
+    color: string;
+    emoji: string;
+  };
+}

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -5,3 +5,4 @@ export { default as postApi } from './post';
 export { default as commentApi } from './comment';
 export { default as missionStatusApi } from './mission-status';
 export { default as likeApi } from './like';
+export { default as routineStatusApi } from './routineStatus';

--- a/src/apis/routineStatus.ts
+++ b/src/apis/routineStatus.ts
@@ -1,0 +1,13 @@
+import { AxiosResponse } from 'axios';
+import { authRequest } from './config';
+
+interface RoutineStatusApiType {
+  getRoutineStatusByDate: (date: string) => Promise<AxiosResponse>;
+}
+
+const routineStatusApi: RoutineStatusApiType = {
+  getRoutineStatusByDate: (date) =>
+    authRequest.get('/routines/routineStatus', { params: { date } }),
+};
+
+export default routineStatusApi;

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -2,6 +2,7 @@ import { Colors } from '@/styles';
 import styled from '@emotion/styled';
 import { RingLoader } from 'react-spinners';
 import { Portal } from '@/components';
+import { useState } from 'react';
 
 export interface SpinnerProps {
   color?: string;
@@ -11,17 +12,24 @@ export interface SpinnerProps {
 }
 
 const Spinner = ({ ...props }: SpinnerProps): JSX.Element => {
+  const [visible, setVisible] = useState<boolean>(false);
+
+  setTimeout(() => {
+    setVisible(true);
+  }, 500);
+
   return (
     <Portal>
-      <BackgroundDim>
+      <BackgroundDim visible={visible}>
         <RingLoader color={Colors.yellow} {...props} />
       </BackgroundDim>
     </Portal>
   );
 };
 
-const BackgroundDim = styled.div`
+const BackgroundDim = styled.div<{ visible: boolean }>`
   display: flex;
+  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
   justify-content: center;
   align-items: center;
   position: fixed;

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -2,7 +2,7 @@ import { Colors } from '@/styles';
 import styled from '@emotion/styled';
 import { RingLoader } from 'react-spinners';
 import { Portal } from '@/components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export interface SpinnerProps {
   color?: string;
@@ -14,9 +14,15 @@ export interface SpinnerProps {
 const Spinner = ({ ...props }: SpinnerProps): JSX.Element => {
   const [visible, setVisible] = useState<boolean>(false);
 
-  setTimeout(() => {
-    setVisible(true);
-  }, 500);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(true);
+    }, 500);
+
+    return () => {
+      timer && clearTimeout(timer);
+    };
+  }, []);
 
   return (
     <Portal>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -73,6 +73,7 @@ export { RoutineProgressModal } from './organisms/RoutineProgressModal';
 export { RoutineProgress } from './organisms/RoutineProgressModal';
 export { RoutinePost } from './organisms/RoutinePost';
 export { Calendar } from './organisms/Calendar';
+export type { CalendarProps } from './organisms/Calendar';
 
 //! Template Component
 export { Container } from './templates/Container';

--- a/src/components/organisms/Calendar/Calendar.tsx
+++ b/src/components/organisms/Calendar/Calendar.tsx
@@ -16,12 +16,14 @@ type highlightDatesType = {
 
 export interface CalendarProps extends React.ComponentProps<'div'> {
   onClickDate?: (date: dayjs.Dayjs) => void;
+  onChangeYearMonth?: (date: dayjs.Dayjs) => void;
   highlightDates?: highlightDatesType;
   markedDates?: dayjs.Dayjs[];
 }
 
 const Calendar = ({
   onClickDate,
+  onChangeYearMonth,
   highlightDates,
   markedDates: rawMarkedDates = [],
   ...props
@@ -39,6 +41,7 @@ const Calendar = ({
       yearMonth.get('year'),
       yearMonth.get('month'),
     );
+    onChangeYearMonth && onChangeYearMonth(yearMonth);
     setCalendarDates(newCalendarDates);
   };
 

--- a/src/components/organisms/Calendar/Calendar.tsx
+++ b/src/components/organisms/Calendar/Calendar.tsx
@@ -17,6 +17,7 @@ type highlightDatesType = {
 export interface CalendarProps extends React.ComponentProps<'div'> {
   onClickDate?: (date: dayjs.Dayjs) => void;
   onChangeYearMonth?: (date: dayjs.Dayjs) => void;
+  initialSelectedDate?: dayjs.Dayjs;
   highlightDates?: highlightDatesType;
   markedDates?: dayjs.Dayjs[];
 }
@@ -25,13 +26,15 @@ const Calendar = ({
   onClickDate,
   onChangeYearMonth,
   highlightDates,
+  initialSelectedDate = dayjs(),
   markedDates: rawMarkedDates = [],
   ...props
 }: CalendarProps): JSX.Element => {
   const [calendarDates, setCalendarDates] = useState<
     (dayjs.Dayjs | undefined)[][]
   >([]);
-  const [selectedDate, setSelectedDate] = useState<dayjs.Dayjs>(dayjs());
+  const [selectedDate, setSelectedDate] =
+    useState<dayjs.Dayjs>(initialSelectedDate);
   const markedDates: string[] = useMemo(() => {
     return rawMarkedDates.map((date) => date.format('YYYY-MM-DD'));
   }, [rawMarkedDates]);

--- a/src/components/organisms/Calendar/index.ts
+++ b/src/components/organisms/Calendar/index.ts
@@ -1,1 +1,2 @@
 export { default as Calendar } from './Calendar';
+export type { CalendarProps } from './Calendar';

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Container, Calendar } from '@/components';
 import styled from '@emotion/styled';
 import { Colors, FontSize, FontWeight, Media } from '@/styles';
+import { routineStatusApi } from '@/apis';
 
 const AnalysisPage = (): JSX.Element => {
   return (

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
-import { Media } from '@/styles';
+import { Media, Colors, FontSize } from '@/styles';
 import { routineStatusApi } from '@/apis';
 import { Container, Calendar, Routine, Spinner } from '@/components';
 import { useHistory } from 'react-router-dom';
@@ -106,6 +106,12 @@ const AnalysisPage = (): JSX.Element => {
           );
         })}
       </RoutineStatusContainer>
+      {routineStatuses.length <= 0 && (
+        <InfoContainer>
+          <EmojiText>😅</EmojiText>
+          <Text>해당 날짜에는 수행한 루틴이 없습니다.</Text>
+        </InfoContainer>
+      )}
       {loading && <Spinner />}
     </Container>
   );
@@ -134,6 +140,25 @@ const RoutineStatusContainer = styled.div`
       grid-template-columns: repeat(2, 1fr);
     }
   }
+`;
+
+const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin-top: 1rem;
+`;
+
+const EmojiText = styled.p`
+  font-size: 40px;
+  margin: 2rem 0;
+`;
+
+const Text = styled.p`
+  color: ${Colors.textPrimary};
+  font-size: ${FontSize.medium};
 `;
 
 export default AnalysisPage;

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import styled from '@emotion/styled';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Media } from '@/styles';
 import { routineStatusApi } from '@/apis';
 import { Container, Calendar, Routine, Spinner } from '@/components';
@@ -11,23 +11,6 @@ interface highlightDatesType {
   [key: string]: number;
 }
 
-const parseHighlightDates = (
-  routineStatusData: RoutineStatusType[],
-): highlightDatesType => {
-  const highlightDates: highlightDatesType = {};
-
-  routineStatusData.forEach((routineStatus: RoutineStatusType) => {
-    const date = dayjs(routineStatus.dateTime.slice(0, 11)).format(
-      'YYYY-MM-DD',
-    );
-    highlightDates[date]
-      ? (highlightDates[date] += 1)
-      : (highlightDates[date] = 1);
-  });
-
-  return highlightDates;
-};
-
 const AnalysisPage = (): JSX.Element => {
   const history = useHistory();
   const [loading, setLoading] = useState<boolean>(false);
@@ -36,18 +19,34 @@ const AnalysisPage = (): JSX.Element => {
     [],
   );
 
-  const getRoutineStatusByDate = useCallback(
-    async (date: string): Promise<RoutineStatusType[]> => {
-      try {
-        const res = await routineStatusApi.getRoutineStatusByDate(date);
-        const routineStatus = res.data.data;
-        return routineStatus;
-      } catch (error) {
-        return [];
-      }
-    },
-    [],
-  );
+  const getRoutineStatusByDate = async (
+    date: string,
+  ): Promise<RoutineStatusType[]> => {
+    try {
+      const res = await routineStatusApi.getRoutineStatusByDate(date);
+      const routineStatus = res.data.data;
+      return routineStatus;
+    } catch (error) {
+      return [];
+    }
+  };
+
+  const parseHighlightDates = (
+    routineStatusData: RoutineStatusType[],
+  ): highlightDatesType => {
+    const highlightDates: highlightDatesType = {};
+
+    routineStatusData.forEach((routineStatus: RoutineStatusType) => {
+      const date = dayjs(routineStatus.dateTime.slice(0, 11)).format(
+        'YYYY-MM-DD',
+      );
+      highlightDates[date]
+        ? (highlightDates[date] += 1)
+        : (highlightDates[date] = 1);
+    });
+
+    return highlightDates;
+  };
 
   const handleClickDate = async (date: dayjs.Dayjs) => {
     setLoading(true);
@@ -85,7 +84,7 @@ const AnalysisPage = (): JSX.Element => {
     };
 
     init();
-  }, [getRoutineStatusByDate]);
+  }, []);
 
   return (
     <Container navBar>

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -115,6 +115,7 @@ const AnalysisPage = (): JSX.Element => {
 
 const StyledCalendar = styled(Calendar)`
   margin-top: 1rem;
+  min-height: 510px;
 `;
 
 const RoutineStatusContainer = styled.div`

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -1,13 +1,66 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Container, Calendar } from '@/components';
 import styled from '@emotion/styled';
 import { Colors, FontSize, FontWeight, Media } from '@/styles';
 import { routineStatusApi } from '@/apis';
+import dayjs from 'dayjs';
+
+type highlightDatesType = {
+  [key: string]: number;
+};
+
+type routineStatusType = {
+  dateTime: string;
+};
+
+const parseHighlightDates = (
+  routineStatusData: routineStatusType[],
+): highlightDatesType => {
+  const highlightDates: highlightDatesType = {};
+  routineStatusData.forEach((routineStatus: routineStatusType) => {
+    const date = dayjs(routineStatus.dateTime).format('YYYY-MM-DD');
+    highlightDates[date]
+      ? (highlightDates[date] += 1)
+      : (highlightDates[date] = 1);
+  });
+  return highlightDates;
+};
 
 const AnalysisPage = (): JSX.Element => {
+  const [highlightDates, setHighlightDates] = useState<highlightDatesType>({});
+
+  const handleClickDate = (date: dayjs.Dayjs) => {
+    console.log('handleClickDate');
+    // getRoutineStatusByDate(date);
+  };
+
+  const getRoutineStatusByDate = useCallback(async (date: string) => {
+    try {
+      const res = await routineStatusApi.getRoutineStatusByDate(date);
+      const routineStatus = res.data.data;
+      return routineStatus;
+    } catch (error) {
+      return [];
+    }
+  }, []);
+
+  useEffect(() => {
+    console.log('useEffect');
+
+    const init = async () => {
+      const today = dayjs().format('YYYY-MM');
+      const routineStatusData = await getRoutineStatusByDate(today);
+      const highlightDates = parseHighlightDates(routineStatusData);
+      setHighlightDates(highlightDates);
+      console.log(routineStatusData, highlightDates);
+    };
+
+    init();
+  }, []);
+
   return (
     <Container navBar>
-      <Calendar />
+      <Calendar highlightDates={highlightDates} onClickDate={handleClickDate} />
     </Container>
   );
 };

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -1,68 +1,140 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { Container, Calendar } from '@/components';
-import styled from '@emotion/styled';
-import { Colors, FontSize, FontWeight, Media } from '@/styles';
-import { routineStatusApi } from '@/apis';
 import dayjs from 'dayjs';
+import styled from '@emotion/styled';
+import { useCallback, useEffect, useState } from 'react';
+import { Media } from '@/styles';
+import { routineStatusApi } from '@/apis';
+import { Container, Calendar, Routine, Spinner } from '@/components';
+import { useHistory } from 'react-router-dom';
+import { RoutineStatusType } from 'Models';
 
-type highlightDatesType = {
+interface highlightDatesType {
   [key: string]: number;
-};
-
-type routineStatusType = {
-  dateTime: string;
-};
+}
 
 const parseHighlightDates = (
-  routineStatusData: routineStatusType[],
+  routineStatusData: RoutineStatusType[],
 ): highlightDatesType => {
   const highlightDates: highlightDatesType = {};
-  routineStatusData.forEach((routineStatus: routineStatusType) => {
-    const date = dayjs(routineStatus.dateTime).format('YYYY-MM-DD');
+
+  routineStatusData.forEach((routineStatus: RoutineStatusType) => {
+    const date = dayjs(routineStatus.dateTime.slice(0, 11)).format(
+      'YYYY-MM-DD',
+    );
     highlightDates[date]
       ? (highlightDates[date] += 1)
       : (highlightDates[date] = 1);
   });
+
   return highlightDates;
 };
 
 const AnalysisPage = (): JSX.Element => {
+  const history = useHistory();
+  const [loading, setLoading] = useState<boolean>(false);
   const [highlightDates, setHighlightDates] = useState<highlightDatesType>({});
+  const [routineStatuses, setRoutineStatuses] = useState<RoutineStatusType[]>(
+    [],
+  );
 
-  const handleClickDate = (date: dayjs.Dayjs) => {
-    console.log('handleClickDate');
-    // getRoutineStatusByDate(date);
+  const getRoutineStatusByDate = useCallback(
+    async (date: string): Promise<RoutineStatusType[]> => {
+      try {
+        const res = await routineStatusApi.getRoutineStatusByDate(date);
+        const routineStatus = res.data.data;
+        return routineStatus;
+      } catch (error) {
+        return [];
+      }
+    },
+    [],
+  );
+
+  const handleClickDate = async (date: dayjs.Dayjs) => {
+    setLoading(true);
+    const dateString = date.format('YYYY-MM-DD');
+    const routineStatuses = await getRoutineStatusByDate(dateString);
+    setRoutineStatuses(routineStatuses);
+    setLoading(false);
   };
 
-  const getRoutineStatusByDate = useCallback(async (date: string) => {
-    try {
-      const res = await routineStatusApi.getRoutineStatusByDate(date);
-      const routineStatus = res.data.data;
-      return routineStatus;
-    } catch (error) {
-      return [];
-    }
-  }, []);
+  const handleChangeYearMonth = async (yearMonth: dayjs.Dayjs) => {
+    setLoading(true);
+    const yearMonthString = yearMonth.format('YYYY-MM');
+    const routineStatuses = await getRoutineStatusByDate(yearMonthString);
+    const highlightDates = parseHighlightDates(routineStatuses);
+    setHighlightDates(highlightDates);
+    setLoading(false);
+  };
+
+  const handleClickRoutine = (routineStatusId: number) => {
+    console.log('handleClickRoutine', routineStatusId);
+    history.push(`/analysis/detail/${routineStatusId}`);
+  };
 
   useEffect(() => {
-    console.log('useEffect');
-
     const init = async () => {
-      const today = dayjs().format('YYYY-MM');
-      const routineStatusData = await getRoutineStatusByDate(today);
-      const highlightDates = parseHighlightDates(routineStatusData);
+      setLoading(true);
+      const now = dayjs();
+      const yearMonth = now.format('YYYY-MM');
+      const todayDate = now.format('YYYY-MM-DD');
+      const yearMonthRoutineStatuses = await getRoutineStatusByDate(yearMonth);
+      const todayDateRoutineStatuses = await getRoutineStatusByDate(todayDate);
+      const highlightDates = parseHighlightDates(yearMonthRoutineStatuses);
       setHighlightDates(highlightDates);
-      console.log(routineStatusData, highlightDates);
+      setRoutineStatuses(todayDateRoutineStatuses);
+      setLoading(false);
     };
 
     init();
-  }, []);
+  }, [getRoutineStatusByDate]);
 
   return (
     <Container navBar>
-      <Calendar highlightDates={highlightDates} onClickDate={handleClickDate} />
+      <StyledCalendar
+        highlightDates={highlightDates}
+        onClickDate={handleClickDate}
+        onChangeYearMonth={handleChangeYearMonth}
+      />
+      <RoutineStatusContainer>
+        {routineStatuses.map((routineStatus) => {
+          const routine = routineStatus.routineListResponse;
+          return (
+            <Routine
+              key={routine.routineId}
+              type="create"
+              routineObject={routine}
+              onClick={() => handleClickRoutine(routineStatus.routineStatusId)}
+            />
+          );
+        })}
+      </RoutineStatusContainer>
+      {loading && <Spinner />}
     </Container>
   );
 };
+
+const StyledCalendar = styled(Calendar)`
+  margin-top: 1rem;
+`;
+
+const RoutineStatusContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  justify-content: center;
+  justify-items: center;
+  gap: 40px 0;
+  width: 100%;
+  padding: 40px 0;
+
+  @media ${Media.sm} {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px 14px;
+    padding: 20px 0;
+
+    @media (max-width: 480px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+`;
 
 export default AnalysisPage;

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -1,55 +1,14 @@
 import React from 'react';
-import { Container } from '@/components';
+import { Container, Calendar } from '@/components';
 import styled from '@emotion/styled';
-import { analysis } from '@/images';
 import { Colors, FontSize, FontWeight, Media } from '@/styles';
 
 const AnalysisPage = (): JSX.Element => {
   return (
     <Container navBar>
-      <ContentsContainer>
-        <Span>완료한 루틴을 한눈에 확인 가능한</Span>
-        <Span>분석 서비스를 준비 중입니다</Span>
-        <Image src={analysis} alt="이미지" />
-      </ContentsContainer>
+      <Calendar />
     </Container>
   );
 };
+
 export default AnalysisPage;
-
-const ContentsContainer = styled.div`
-  margin-top: 2.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-evenly;
-  min-height: 500px;
-`;
-
-const Span = styled.span`
-  margin: 0.5rem 0;
-  color: ${Colors.textSecondary};
-  font-weight: ${FontWeight.medium};
-  @media ${Media.sm} {
-    font-size: ${FontSize.medium};
-  }
-  @media ${Media.md} {
-    font-size: ${FontSize.large};
-  }
-  @media ${Media.lg} {
-    font-size: ${FontSize.large};
-  }
-`;
-
-const Image = styled.img`
-  margin-top: 1.5rem;
-  @media ${Media.sm} {
-    height: 360px;
-  }
-  @media ${Media.md} {
-    height: 480px;
-  }
-  @media ${Media.lg} {
-    height: 480px;
-  }
-`;

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -67,7 +67,6 @@ const AnalysisPage = (): JSX.Element => {
   };
 
   const handleClickRoutine = (routineStatusId: number) => {
-    console.log('handleClickRoutine', routineStatusId);
     history.push(`/analysis/detail/${routineStatusId}`);
   };
 

--- a/src/pages/analysis/AnalysisPage.tsx
+++ b/src/pages/analysis/AnalysisPage.tsx
@@ -37,9 +37,7 @@ const AnalysisPage = (): JSX.Element => {
     const highlightDates: highlightDatesType = {};
 
     routineStatusData.forEach((routineStatus: RoutineStatusType) => {
-      const date = dayjs(routineStatus.dateTime.slice(0, 11)).format(
-        'YYYY-MM-DD',
-      );
+      const date = dayjs(routineStatus.dateTime).format('YYYY-MM-DD');
       highlightDates[date]
         ? (highlightDates[date] += 1)
         : (highlightDates[date] = 1);

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -94,7 +94,7 @@ const Router = (): JSX.Element => {
         component={SignUpPage}
       />
 
-      <PublicRoute path="/analysis" exact component={AnalysisPage} />
+      <PrivateRoute path="/analysis" exact component={AnalysisPage} />
 
       <PublicRoute path="/onboarding" exact component={OnBoardingPage} />
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

Analysis Page 구현

- close #202 

## 🧑‍💻 PR 세부 내용

- 캘린더 컴포넌트를 활용하여 유저가 루틴을 수행한 날에 하이라이팅을 합니다.
- 캘린더에서 날짜를 선택하면 수행한 루틴 정보가 렌더링 됩니다.

### 추가 리팩토링 - Spinner 컴폰포넌트

- Spinner 컴포넌트에 렌더링을 0.5초 지연시켰습니다.
- 0.5초 이내에 서버로부터 응답이온다면 Spinner는 렌더링이 되지 않습니다.
- 0.5초 이상 지연이된다면 0.5초부터 스피너는 렌더링이 되도록 활용할 수 있습니다.
- 최종적으로 Spinner 컴포넌트에 의한 깜빡이는 현상을 제거하였습니다.

## 📸 스크린샷


https://user-images.githubusercontent.com/41064875/151761083-12458c64-73d4-4bb8-ac87-3649876fee50.mov



### Spinner 리팩토링
https://user-images.githubusercontent.com/41064875/151761440-29ae12cd-a0e8-489f-9c42-c7c34c2ad371.mov


