### PR TITLE
fix: #204/Component Bug

### DIFF
--- a/src/components/atoms/IconButton/Add.tsx
+++ b/src/components/atoms/IconButton/Add.tsx
@@ -1,5 +1,5 @@
 import { IconButtonProps } from './IconButton';
-import { Colors, Media, Shadow } from '@/styles';
+import { Colors, Media } from '@/styles';
 import styled from '@emotion/styled';
 
 const Add = ({ ...props }: IconButtonProps): JSX.Element => {

--- a/src/components/atoms/IconButton/Add.tsx
+++ b/src/components/atoms/IconButton/Add.tsx
@@ -29,7 +29,6 @@ const StyledButton = styled.button`
   border-radius: 50%;
   background-color: ${Colors.point};
   cursor: pointer;
-  box-shadow: ${Shadow.button};
 
   @media ${Media.sm} {
     width: 42px;

--- a/src/components/molecules/CommentCreator/CommentCreator.tsx
+++ b/src/components/molecules/CommentCreator/CommentCreator.tsx
@@ -3,23 +3,34 @@ import styled from '@emotion/styled';
 import { Colors, Media, FontSize } from '@/styles';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/store';
+import Swal from 'sweetalert2';
 
 export interface CommentCreatorProps
   extends Omit<React.ComponentProps<'form'>, 'onChange' | 'onSubmit'> {
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onSubmit?: (value: string) => void;
+  contentLimit?: number;
 }
 
 const CommentCreator = ({
   onChange,
   onSubmit,
+  contentLimit = 127,
   ...props
 }: CommentCreatorProps): JSX.Element => {
   const [content, setContent] = useState<string>('');
   const user = useSelector((state: RootState) => state.user.data);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
-    setContent(e.target.value);
+    const content = e.target.value;
+    if (content.length > 127) {
+      Swal.fire({
+        icon: 'warning',
+        text: '댓글은 127글자 이내로 작성해주세요.',
+      });
+      return;
+    }
+    setContent(content);
     onChange && onChange(e);
   };
 

--- a/src/components/molecules/RoutinePostContent/RoutinePostContent.tsx
+++ b/src/components/molecules/RoutinePostContent/RoutinePostContent.tsx
@@ -62,7 +62,6 @@ const TextArea = styled.textarea<
   }
 >`
   width: 100%;
-  height: ${({ opened, height }) => (opened ? `${height}px` : '1.8rem')};
   overflow-y: hidden;
   text-overflow: ellipsis;
   background-color: transparent;
@@ -73,12 +72,15 @@ const TextArea = styled.textarea<
 
   @media ${Media.sm} {
     font-size: ${FontSize.small};
+    height: ${({ opened, height }) => (opened ? `${height}px` : '1.5rem')};
   }
   @media ${Media.md} {
     font-size: ${FontSize.base};
+    height: ${({ opened, height }) => (opened ? `${height}px` : '1.8rem')};
   }
   @media ${Media.lg} {
     font-size: ${FontSize.base};
+    height: ${({ opened, height }) => (opened ? `${height}px` : '1.8rem')};
   }
 `;
 

--- a/src/components/organisms/Comment/Comment.tsx
+++ b/src/components/organisms/Comment/Comment.tsx
@@ -17,6 +17,7 @@ export interface CommentProps extends React.ComponentProps<'div'> {
   onClickLikeToggle?: (commentId: number, prevToggled: boolean) => void;
   likeToggled?: boolean;
   likeCount?: number;
+  likesToggleInteractive?: boolean;
 }
 
 const Comment = ({
@@ -27,6 +28,7 @@ const Comment = ({
   onClickLikeToggle,
   likeToggled,
   likeCount,
+  likesToggleInteractive = false,
   ...props
 }: CommentProps): JSX.Element => {
   const ref = useRef<HTMLTextAreaElement>(null);
@@ -92,7 +94,7 @@ const Comment = ({
         </UserInfoContainer>
         <ToolWrapper>
           <LikeBox
-            interactive
+            interactive={likesToggleInteractive}
             active={likeToggled}
             count={likeCount ? likeCount : 0}
             onClick={handleClickLikeButton}

--- a/src/components/organisms/RoutineAddButton/RoutineAddButton.tsx
+++ b/src/components/organisms/RoutineAddButton/RoutineAddButton.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { IconButton, IconButtonProps, Button, Icon } from '@/components';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { Colors, FontSize, FontWeight, Media } from '@/styles';
+import { Colors, FontSize, FontWeight, Media, Shadow } from '@/styles';
 import { useHistory } from 'react-router-dom';
 
 export type RoutineAddButtonProps = React.ComponentProps<'div'>;
@@ -35,12 +35,14 @@ const RoutineAddButton = ({ ...props }: RoutineAddButtonProps): JSX.Element => {
           </StyledButton>
         </ButtonWrapper>
       )}
-      <AddButton
-        open={active}
-        onClick={() => {
-          setActive((active) => !active);
-        }}
-      />
+      <AddButtonWrapper>
+        <AddButton
+          open={active}
+          onClick={() => {
+            setActive((active) => !active);
+          }}
+        />
+      </AddButtonWrapper>
     </Container>
   );
 };
@@ -91,8 +93,14 @@ const StyledButton = styled(Button)`
   }
 `;
 
-const AddButton = styled(IconButton.Add)<IconButtonProps & { open: boolean }>`
+const AddButtonWrapper = styled.div`
   align-self: flex-end;
+  box-shadow: ${Shadow.button};
+  border-radius: 50%;
+  background-color: transparent;
+`;
+
+const AddButton = styled(IconButton.Add)<IconButtonProps & { open: boolean }>`
   transition: 0.125s all ease-out;
 
   ${({ open }) =>

--- a/src/components/organisms/RoutinePost/RoutinePost.tsx
+++ b/src/components/organisms/RoutinePost/RoutinePost.tsx
@@ -22,7 +22,6 @@ const RoutinePost = ({
     user,
     routine,
     likesResponse: likes,
-    createdAt,
     updatedAt,
   },
   onClickRoutinePost,

--- a/src/pages/routineCommunity/RoutinePostDetailPage.tsx
+++ b/src/pages/routineCommunity/RoutinePostDetailPage.tsx
@@ -233,6 +233,7 @@ const RoutinePostDetailPage = (): JSX.Element => {
               likeToggled={comment.likes.some(
                 (like) => like.userId === loginUser?.userId,
               )}
+              likesToggleInteractive={loginUser ? true : false}
               likeCount={comment.likes.length}
               comment={comment}
             />

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -84,10 +84,10 @@ const SignUpPage = (): JSX.Element => {
         }).then(() => {
           history.push('/mypage/signin');
         });
-      } catch (error) {
+      } catch (error: any) {
         Swal.fire({
           icon: 'error',
-          text: `회원가입에 실패하였습니다.`,
+          text: `${error?.fieldErrors?.reason ?? '회원가입에 실패하였습니다.'}`,
           confirmButtonColor: Colors.point,
         });
       }

--- a/src/pages/user/UserEditPage.tsx
+++ b/src/pages/user/UserEditPage.tsx
@@ -68,10 +68,10 @@ const UserEditPage = (): JSX.Element => {
         }).then(() => {
           history.push(`/mypage`);
         });
-      } catch (error) {
+      } catch (error: any) {
         Swal.fire({
           icon: 'error',
-          text: `${error}`,
+          text: `${error.message}`,
           confirmButtonColor: Colors.point,
         });
       }

--- a/src/pages/user/UserEditPage.tsx
+++ b/src/pages/user/UserEditPage.tsx
@@ -71,7 +71,7 @@ const UserEditPage = (): JSX.Element => {
       } catch (error: any) {
         Swal.fire({
           icon: 'error',
-          text: `${error.message}`,
+          text: `${error?.fieldErrors?.reason ?? '오류가 발생했습니다.'}`,
           confirmButtonColor: Colors.point,
         });
       }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

Component에 존재하는 버그들 수정

- close #204 

## 🧑‍💻 PR 세부 내용

- [x]  루틴 추가 버튼 클릭 회전시 그림자 회전되는 버그 수정
- [x]  로그인 안했을 때 댓글의 좋아요 클릭시 하트 색칠되는 버그 수정
- [x]  RoutinePostDetailPage, 모바일일 때 content 펼치기 높이 안맞는거 수정하기
- Comment
    - [x]  댓글 작성 127글자로 제한두기 (서버에서 댓글의 글자 length가 255로 제한이 있음)
- UserEditPage
    - [x]  API 에러 메세지 Alert에 연결
- SignUpPage
    - [x]  API 에러 메세지 Alert에 연결


## 📸 스크린샷

### 루틴 추가 버튼 클릭 회전시 그림자 회전되는 버그 수정
- 수정 전
![화면 기록 2022-02-01 오후 8 27 22](https://user-images.githubusercontent.com/41064875/151960805-a93159eb-c775-45a8-b4c7-36d91e3341af.gif)

- 수정 후
![화면 기록 2022-02-01 오후 8 27 41](https://user-images.githubusercontent.com/41064875/151960814-9abe6102-93d2-42e3-b567-968a6aa5de13.gif)

###  로그인 안했을 때 댓글의 좋아요 클릭시 하트 색칠되는 버그 수정
- 수정전
![화면 기록 2022-02-01 오후 8 31 19](https://user-images.githubusercontent.com/41064875/151961368-8a381a09-eeee-45fb-8b9b-e7218efa7f5e.gif)


- 수정후
![화면 기록 2022-02-01 오후 8 32 08](https://user-images.githubusercontent.com/41064875/151961380-a28168a3-760d-4933-b72e-98909f7cfe22.gif)


### RoutinePostDetailPage, 모바일일 때 content 펼치기 높이 안 맞는거 수정하기
- 수정 전
![2022-02-01_20-34-02](https://user-images.githubusercontent.com/41064875/151961528-d8f75aee-9fb5-4ea6-ad7f-7e38b6a50057.png)

- 수정 후
![2022-02-01_20-34-15](https://user-images.githubusercontent.com/41064875/151961536-5f74f505-217e-45dc-8cea-2fdf897f7353.png)

### 댓글 작성 127글자로 제한두기 (서버에서 댓글의 글자 length가 255로 제한이 있음)
![화면 기록 2022-02-01 오후 8 35 35](https://user-images.githubusercontent.com/41064875/151961759-4e9c6f26-7738-453d-a760-3e7a89b41284.gif)



