### PR TITLE
refactor : #206/Page Component - RoutineFinishPage

### DIFF
--- a/src/apis/routine.ts
+++ b/src/apis/routine.ts
@@ -32,7 +32,8 @@ interface RoutineApiType {
     missionCreateRequest: MissionType[];
   }) => Promise<AxiosResponse>;
   creatRoutineReview: (formData: FormData) => Promise<AxiosResponse>;
-  getRoutineStatus: (routineId: number) => Promise<AxiosResponse>;
+  getRoutineStatus: (routineStatusId: number) => Promise<AxiosResponse>;
+  deleteRoutineReview: (routineStatusId: number) => Promise<AxiosResponse>;
 }
 
 const routineApi: RoutineApiType = {
@@ -48,8 +49,10 @@ const routineApi: RoutineApiType = {
     authRequest.post('/routines/my', routineInfo),
   creatRoutineReview: (formData) =>
     authRequest.put('/routines/routineStatus', formData),
-  getRoutineStatus: (routineId) =>
-    authRequest.get(`/routines/routineStatus/${routineId}`),
+  getRoutineStatus: (routineStatusId) =>
+    authRequest.get(`/routines/routineStatus/${routineStatusId}`),
+  deleteRoutineReview: (routineStatusId) =>
+    authRequest.delete(`/routines/routineStatus/${routineStatusId}`),
 };
 
 export default routineApi;

--- a/src/components/molecules/RoutineReview/RoutineReview.tsx
+++ b/src/components/molecules/RoutineReview/RoutineReview.tsx
@@ -40,13 +40,11 @@ const RoutineReview = ({
   const handleClickSpreadToggle = () => {
     setOpened((opened) => !opened);
   };
-
   useEffect(() => {
     if (ref.current) {
       setParagraphHeight(ref.current.scrollHeight);
     }
-    // eslint-disable-next-line
-  }, [ref.current]);
+  }, [reviewData.content]);
 
   const handleCloseToolBox = () => {
     setVisible(false);
@@ -187,8 +185,9 @@ const RoutineReviewContainer = styled.div<{ reviewData: ReviewDataType }>`
 `;
 
 const ReviewText = styled.p`
-  font-size: ${FontSize.medium};
   color: ${Colors.textTertiary};
+  font-size: ${FontSize.medium};
+  word-break: keep-all;
 `;
 
 const ReviewEmotion = styled.img`
@@ -207,7 +206,7 @@ const ReviewEmotion = styled.img`
 `;
 
 const StyledButton = styled(Button)`
-  width: 16.875rem;
+  width: 60%;
 `;
 
 const ReviewEmotionContainer = styled.div`
@@ -253,7 +252,7 @@ const ReviewImageContainer = styled.div`
   img {
     border-radius: 1rem;
     @media ${Media.sm} {
-      height: 100px;
+      height: 80px;
     }
     @media ${Media.md} {
       height: 120px;
@@ -269,14 +268,23 @@ const ReviewContent = styled.p<{
   height: number;
   withPhoto: boolean;
 }>`
-  font-size: ${FontSize.medium};
   color: ${Colors.textPrimary};
   font-weight: ${FontWeight.medium};
   white-space: break-spaces;
+  word-break: keep-all;
   line-height: 1.625rem;
   overflow: hidden;
   height: ${({ opened, height, withPhoto }) =>
     opened ? `${height}` : withPhoto ? '2rem' : '3.2rem'};
+  @media ${Media.sm} {
+    font-size: ${FontSize.small};
+  }
+  @media ${Media.md} {
+    font-size: ${FontSize.medium};
+  }
+  @media ${Media.lg} {
+    font-size: ${FontSize.medium};
+  }
 `;
 
 const StyledSpreadToggle = styled(SpreadToggle)`

--- a/src/pages/myRoutine/RoutineFinishPage.tsx
+++ b/src/pages/myRoutine/RoutineFinishPage.tsx
@@ -176,19 +176,31 @@ const RoutineFinishPage = (): JSX.Element => {
       { type: 'application/json' },
     );
     fileFormData.append('routineStatusCreateRequest', reviewDataBlob);
-    try {
-      await routineApi.creatRoutineReview(fileFormData);
-      Swal.fire({
-        icon: 'success',
-        text: '루틴 후기가 삭제 되었습니다!',
-      });
-      setReviewInfo(initialReview);
-    } catch (error) {
-      Swal.fire({
-        icon: 'error',
-        text: '오류로 인해 루틴 후기 삭제에 실패했습니다!',
-      });
-    }
+    Swal.fire({
+      icon: 'question',
+      text: '루틴 후기를 삭제하시겠습니까?',
+      showCancelButton: true,
+      confirmButtonColor: `${Colors.functionPositive}`,
+      cancelButtonColor: `${Colors.functionNegative}`,
+      confirmButtonText: '네',
+      cancelButtonText: '아니오',
+    }).then(async (result) => {
+      if (result.isConfirmed) {
+        try {
+          await routineApi.creatRoutineReview(fileFormData);
+          Swal.fire({
+            icon: 'success',
+            text: '루틴 후기가 삭제 되었습니다!',
+          });
+          setReviewInfo(initialReview);
+        } catch (error) {
+          Swal.fire({
+            icon: 'error',
+            text: '오류로 인해 루틴 후기 삭제에 실패했습니다!',
+          });
+        }
+      }
+    });
   };
 
   const handleCloseClick = () => {


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

루틴 완료 페이지 내 루틴 리뷰 수정, 삭제 API 연동
- #206 

## 🧑‍💻 PR 세부 내용

- 백엔드와 상의해서 삭제 API를 사용하지 않고, 리뷰 삭제 시 수정 API를 이용해 초기 상태로 변경되도록 구현했습니다.

## 📸 스크린샷

https://user-images.githubusercontent.com/77623643/154022561-fbe13944-4c7f-41d1-af22-4481c68949c4.mov


